### PR TITLE
Lanczos and ISDF improvements: Code cleanup and debug output

### DIFF
--- a/SIGMA/calculate_sigma.F90z
+++ b/SIGMA/calculate_sigma.F90z
@@ -8,11 +8,9 @@
 ! This file is part of RGWBS. It is distributed under the GPL v1.
 !
 !---------------------------------------------------------------
-subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
-                            sig_en, dft_code, chkpt_in, gvec, kpt, qpt, k_c, k_p, pol, sig_in, &
-                            sig, q_p, nolda, tamm_d, writeqp, snorm, cohsex, hqp_sym, lstop, &
-                            ecuts, qpmix, sig_cut, max_sig, &
-                            isdf_in, doisdf, opt)
+subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, sig_en, dft_code, chkpt_in, gvec, kpt, &
+                            qpt, k_c, k_p, pol, sig_in, sig, q_p, nolda, tamm_d, writeqp, snorm, cohsex, hqp_sym, &
+                            lstop, ecuts, qpmix, sig_cut, max_sig, isdf_in, doisdf, opt)
 
   use typedefs
   use mpi_module
@@ -75,8 +73,7 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
 
   integer, parameter :: pol_unit = 51  ! unit for pol_diag.dat file
   logical :: staticcorr
-  integer :: ii, jj, irp, jrp, iq, ik, jk, isp, isig, &
-             info, chkpt, neig_qp
+  integer :: ii, jj, irp, jrp, iq, ik, jk, isp, isig, info, chkpt, neig_qp
   real(dp) :: tsec(2), xsum, rtmp, epsinv
   integer, allocatable :: iord(:)
 
@@ -95,9 +92,8 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
     !             sigma.chkp.dat).
     !
     chkpt = chkpt_in
-    call Zcalculate_tdlda(gvec, kpt, qpt, k_p, pol, nspin, chkpt, &
-                          tamm_d, nolda, .false., .false., .false., .false., xsum, epsinv, &
-                          isdf_in, opt)
+    call Zcalculate_tdlda(gvec, kpt, qpt, k_p, pol, nspin, chkpt, tamm_d, nolda, .false., .false., .false., .false., &
+                          xsum, epsinv, isdf_in, opt)
     !
     ! Rescale sum rule.
     if (.not. snorm) xsum = one
@@ -227,13 +223,11 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
       do isp = 1, nspin
         jk = sig(isp, ik)%indxk
         call timacc(6, 1, tsec)
-        if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. &
-            sig_in%xc == XC_B3LYP) &
+        if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. sig_in%xc == XC_B3LYP) &
           call Zfock_exchange(gvec, kpt, sig(isp, ik), isp, jk)
         if (sig_in%xc == XC_B3LYP .or. sig_in%xc == XC_LDA_CA .or. &
             sig_in%xc == XC_GGA_PBE .or. sig_in%xc == XC_GGA_BLYP) &
-          call Zmodel_exchange(gvec, kpt, sig(isp, ik), nspin, isp, jk, &
-                               sig_in%xc, gvec%syms%ntrans)
+          call Zmodel_exchange(gvec, kpt, sig(isp, ik), nspin, isp, jk, sig_in%xc, gvec%syms%ntrans)
         call timacc(6, 2, tsec)
       end do
     end do
@@ -258,21 +252,21 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
     end if
 
     ! Debug: WG
-!     if (peinf%master .and. doisdf) then
-!        ! print out Mmtrx and Psi_intp
-!        write(6,*) "mu  nu Mmtrx(mu,nu) : "
-!        do ii = 1, isdf_in%n_intp_r
-!          do jj = 1, isdf_in%n_intp_r
-!            write(6,*) ii,jj,isdf_in%Mmtrx(ii, jj, 1, 1, 1, 1, 1)
-!          enddo
-!        enddo
-!        write(6,*) "iband mu Psi_intp(iband, mu)"
-!        do ii = 1, isdf_in%maxicc
-!          do jj = 1, isdf_in%n_intp_r
-!            write(6,*) ii, jj, isdf_in%Psi_intp(jj, ii, 1, 1)
-!          enddo
-!        enddo
-!     endif
+    ! if (peinf%master .and. doisdf) then
+    !    ! print out Mmtrx and Psi_intp
+    !    write(6,*) "mu  nu Mmtrx(mu,nu) : "
+    !    do ii = 1, isdf_in%n_intp_r
+    !      do jj = 1, isdf_in%n_intp_r
+    !        write(6,*) ii,jj,isdf_in%Mmtrx(ii, jj, 1, 1, 1, 1, 1)
+    !      enddo
+    !    enddo
+    !    write(6,*) "iband mu Psi_intp(iband, mu)"
+    !    do ii = 1, isdf_in%maxicc
+    !      do jj = 1, isdf_in%n_intp_r
+    !        write(6,*) ii, jj, isdf_in%Psi_intp(jj, ii, 1, 1)
+    !      enddo
+    !    enddo
+    ! endif
     ! Debug: WG
 
     do iq = 1, qpt%nk
@@ -280,10 +274,8 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
       do jrp = 1, gvec%syms%ntrans/r_grp%num
         irp = r_grp%g_rep(jrp)
         if ((chkpt - (qpt%nk + iq)*gvec%syms%ntrans >= irp)) cycle
-        call Zgw_correlation(gvec, kpt, qpt, k_c(irp, iq), pol(irp, iq), &
-                             sig_in, sig, nspin, nkpt, irp, &
-                             pol_unit, k_p(irp, iq)%nn, qpt%nk, iq, sig_en, nolda, xsum, &
-                             isdf_in, opt)
+        call Zgw_correlation(gvec, kpt, qpt, k_c(irp, iq), pol(irp, iq), sig_in, sig, nspin, nkpt, irp, pol_unit, &
+                             k_p(irp, iq)%nn, qpt%nk, iq, sig_en, nolda, xsum, isdf_in, opt)
       end do
       call stopwatch(peinf%master, "after call gw_correlation")
 #ifdef MPI
@@ -398,8 +390,7 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
     end do
   end if
 
-  call stopwatch(r_grp%master, &
-                 ' All matrix elements calculated. Start printout')
+  call stopwatch(r_grp%master, ' All matrix elements calculated. Start printout')
 
   if (peinf%master .and. sig_in%xc == XC_GW) then
     open (12, file='hmat_qp_nostatic', form='formatted')
@@ -532,9 +523,8 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
         !
         ! Print self-energy tables without static correction.
         !
-        call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), &
-                        kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), 12, &
-                        isp, ik, iord, qpmix, rtmp, file_name)
+        call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), &
+                        12, isp, ik, iord, qpmix, rtmp, file_name)
         !
         ! Update and print self-energy with static correction.
         !
@@ -579,9 +569,8 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
               end if
             end if
           end if
-          call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), &
-                          kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), 15, &
-                          isp, ik, iord, qpmix, max_sig, file_name)
+          call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), &
+                          15, isp, ik, iord, qpmix, max_sig, file_name)
         end if
       end if
       deallocate (iord)
@@ -593,8 +582,7 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
     if (staticcorr) close (15)
   end if
 #ifdef MPI
-  call MPI_BCAST(max_sig, 1, MPI_DOUBLE_PRECISION, &
-                 peinf%masterid, peinf%comm, info)
+  call MPI_BCAST(max_sig, 1, MPI_DOUBLE_PRECISION, peinf%masterid, peinf%comm, info)
 #endif
 
   !-------------------------------------------------------------------
@@ -611,8 +599,7 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
       if (sig_in%xc == XC_GW) then
         deallocate (kpt%wfn(isp, jk)%mapd)
         deallocate (kpt%wfn(isp, jk)%Zdipole)
-        call Zget_dipole(gvec, kpt%wfn(isp, jk), jk, kpt%fk(1, jk), &
-                         kpt%wfn(isp, jk)%occ0)
+        call Zget_dipole(gvec, kpt%wfn(isp, jk), jk, kpt%fk(1, jk), kpt%wfn(isp, jk)%occ0)
       end if
     end do
 
@@ -638,40 +625,30 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
     do iq = 1, qpt%nk
       do irp = 1, gvec%syms%ntrans
         if (pol(irp, iq)%n_up > 0) &
-          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, &
-                           2*pol(irp, iq)%n_up, pol(irp, iq)%tr)
+          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, 2*pol(irp, iq)%n_up, pol(irp, iq)%tr)
         if (k_p(irp, iq)%ncol_up > 0) &
-          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, &
-                           2*k_p(irp, iq)%ncol_up, k_p(irp, iq)%col)
+          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, 2*k_p(irp, iq)%ncol_up, k_p(irp, iq)%col)
         if (k_p(irp, iq)%nrow_up > 0) &
-          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, &
-                           2*k_p(irp, iq)%nrow_up, k_p(irp, iq)%row)
+          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, 2*k_p(irp, iq)%nrow_up, k_p(irp, iq)%row)
         if (k_c(irp, iq)%ncol_up > 0) &
-          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, &
-                           2*k_c(irp, iq)%ncol_up, k_c(irp, iq)%col)
+          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, 2*k_c(irp, iq)%ncol_up, k_c(irp, iq)%col)
         if (k_c(irp, iq)%nrow_up > 0) &
-          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, &
-                           2*k_c(irp, iq)%nrow_up, k_c(irp, iq)%row)
+          call inverse_map(kpt%wfn(1, 1)%nstate, kpt%wfn(1, 1)%cmapi, 2*k_c(irp, iq)%nrow_up, k_c(irp, iq)%row)
         if (nspin == 2) then
           if (pol(irp, iq)%ntr - pol(irp, iq)%n_up > 0) &
-            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, &
-                             2*(pol(irp, iq)%ntr - pol(irp, iq)%n_up), &
+            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, 2*(pol(irp, iq)%ntr - pol(irp, iq)%n_up), &
                              pol(irp, iq)%tr(1, pol(irp, iq)%n_up + 1))
           if (k_p(irp, iq)%nrow - k_p(irp, iq)%nrow_up > 0) &
-            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, &
-                             2*(k_p(irp, iq)%nrow - k_p(irp, iq)%nrow_up), &
+            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, 2*(k_p(irp, iq)%nrow - k_p(irp, iq)%nrow_up), &
                              k_p(irp, iq)%row(1, k_p(irp, iq)%nrow_up + 1))
           if (k_p(irp, iq)%ncol - k_p(irp, iq)%ncol_up > 0) &
-            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, &
-                             2*(k_p(irp, iq)%ncol - k_p(irp, iq)%ncol_up), &
+            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, 2*(k_p(irp, iq)%ncol - k_p(irp, iq)%ncol_up), &
                              k_p(irp, iq)%col(1, k_p(irp, iq)%ncol_up + 1))
           if (k_c(irp, iq)%nrow - k_c(irp, iq)%nrow_up > 0) &
-            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, &
-                             2*(k_c(irp, iq)%nrow - k_c(irp, iq)%nrow_up), &
+            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, 2*(k_c(irp, iq)%nrow - k_c(irp, iq)%nrow_up), &
                              k_c(irp, iq)%row(1, k_c(irp, iq)%nrow_up + 1))
           if (k_c(irp, iq)%ncol - k_c(irp, iq)%ncol_up > 0) &
-            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, &
-                             2*(k_c(irp, iq)%ncol - k_c(irp, iq)%ncol_up), &
+            call inverse_map(kpt%wfn(2, 1)%nstate, kpt%wfn(2, 1)%cmapi, 2*(k_c(irp, iq)%ncol - k_c(irp, iq)%ncol_up), &
                              k_c(irp, iq)%col(1, k_c(irp, iq)%ncol_up + 1))
         end if
       end do
@@ -681,8 +658,7 @@ subroutine Zcalculate_sigma(nspin, nkpt, n_it, it_scf, nr_buff, static_type, &
 #ifdef MPI
   call MPI_BARRIER(peinf%comm, info)
 #endif
-  if (peinf%master) write (6, '(/,a,i5,a,f10.5,/)') ' Iteration ', &
-    it_scf, '. Maximum potential (eV) = ', max_sig
+  if (peinf%master) write (6, '(/,a,i5,a,f10.5,/)') ' Iteration ', it_scf, '. Maximum potential (eV) = ', max_sig
 
 end subroutine Zcalculate_sigma
 !===================================================================

--- a/SIGMA/calculate_sigma_lanczos.F90z
+++ b/SIGMA/calculate_sigma_lanczos.F90z
@@ -6,11 +6,9 @@
 ! Author: Weiwei Gao @ Dalian Univ. of Tech.
 !
 !---------------------------------------------------------------
-subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
-                                    sig_en, dft_code, gvec, kpt, qpt, k_c, k_p, sig_in, &
-                                    sig, q_p, nolda, tamm_d, writeqp, snorm, cohsex, lstop, &
-                                    ecuts, sig_cut, max_sig, &
-                                    isdf_in, doisdf, opt)
+subroutine Zcalculate_sigma_lanczos(nspin, nkpt, sig_en, dft_code, gvec, kpt, qpt, k_c, k_p, sig_in, sig, q_p, nolda, &
+                                    tamm_d, writeqp, snorm, cohsex, lstop, ecuts, sig_cut, max_sig, isdf_in, doisdf, &
+                                    opt)
 
   use typedefs
   use mpi_module
@@ -62,21 +60,15 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
   character(len=100) :: file_name
 
   logical :: staticcorr
-  integer :: ii, jj, irp, jrp, iq, ik, jk, isp, isig, &
-             info, chkpt, neig_qp, ien, n_intp_loc, ic, iv, icv, &
-             icv_start, icv_end, intp_start, intp_end, ij, incr, &
-             jn, m1, ncv, ncv_loc, iprocs, nval
+  integer :: ii, jj, irp, jrp, iq, ik, jk, isp, isig, info, chkpt, neig_qp, ien, n_intp_loc, ic, iv, icv, &
+             icv_start, icv_end, intp_start, intp_end, ij, incr, jn, m1, ncv, ncv_loc, iprocs, nval
   integer, parameter :: npoly = 6
-  real(dp) :: tsec(2), xsum, rtmp, epsinv, deltae, emin, &
-              emax, en0, pnorm2, res, fit_error
-  real(dp), allocatable :: polynomial(:), Pvec(:), &
-                           tmp_Cmtrx(:, :), tmp_Cvec(:), tmp_CvecM(:), tmp_poly(:), &
-                           sqrtR(:)
+  real(dp) :: tsec(2), xsum, rtmp, epsinv, deltae, emin, emax, en0, pnorm2, res, fit_error
+  real(dp), allocatable :: polynomial(:), Pvec(:), tmp_Cmtrx(:, :), tmp_Cvec(:), tmp_CvecM(:), tmp_poly(:), sqrtR(:)
   integer, allocatable :: iord(:), cvpair(:, :)
   integer, parameter :: it_scf = 0, niter = 15
   real(dp), parameter :: qpmix = 1.d0
-  complex(dp), allocatable :: zz(:), ezz(:), sigma_corr(:), &
-                              sigma_corr_tmp(:)
+  complex(dp), allocatable :: zz(:), ezz(:), sigma_corr(:), sigma_corr_tmp(:)
   real(dp), external :: ddot
 
   if (peinf%master) print *, "ecuts ", ecuts
@@ -124,8 +116,7 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
     do isp = 1, nspin
       jk = sig(isp, ik)%indxk
       call timacc(6, 1, tsec)
-      if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. &
-          sig_in%xc == XC_B3LYP) &
+      if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. sig_in%xc == XC_B3LYP) &
         call Zfock_exchange(gvec, kpt, sig(isp, ik), isp, jk)
       call timacc(6, 2, tsec)
     end do
@@ -143,10 +134,8 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
     ! fit a polynomial
     nval = sum(kpt%wfn(1, 1)%occ0) ! only works for systems with a gap
     if (peinf%master) then
-      emin = (kpt%wfn(1, 1)%e1(nval + 1) - &
-              kpt%wfn(1, 1)%e1(nval))**2.0/1.25d0
-      emax = (kpt%wfn(1, 1)%e1(isdf_in%maxicc) - &
-              kpt%wfn(1, 1)%e1(1))**2.0*1.25d0
+      emin = (kpt%wfn(1, 1)%e1(nval + 1) - kpt%wfn(1, 1)%e1(nval))**2.0/1.25d0
+      emax = (kpt%wfn(1, 1)%e1(isdf_in%maxicc) - kpt%wfn(1, 1)%e1(1))**2.0*1.25d0
       print *, "emin = ", emin, " emax = ", emax
       call polyfit_sqrt(emin, emax, npoly, 20, peinf%inode, tmp_poly, fit_error, .true.)
     end if
@@ -199,15 +188,10 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
     allocate (tmp_CvecM(n_intp_loc))
     allocate (sqrtR(ncv_loc))
     ! check local indices
-    if (peinf%master) print *, &
-      " icv_start  icv_end ", &
-      " intp_start  intp_end ", &
-      " ncv_loc  n_intp_loc "
+    if (peinf%master) print *, " icv_start  icv_end  intp_start  intp_end  ncv_loc  n_intp_loc "
     do iprocs = 0, peinf%npes - 1
       if (peinf%inode == iprocs) then
-        print *, icv_start, icv_end, &
-          intp_start, intp_end, &
-          ncv_loc, n_intp_loc
+        print *, icv_start, icv_end, intp_start, intp_end, ncv_loc, n_intp_loc
       end if
       call MPI_Barrier(peinf%comm, info)
     end do
@@ -271,13 +255,11 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
           ! = tmp_Cvec(1, n_intp_r) @ Mmtrx(1:n_intp_r, intp_start:intp_end)
           ! or
           ! = Mmtrx(intp_start:intp_end, 1:n_intp_r) @ tmp_Cvec(n_intp_r)
-          call dgemv('N', n_intp_loc, isdf_in%n_intp_r, 1.d0, &
-                     isdf_in%Mmtrx(intp_start, 1, 1, 1, 1, 1, 1), isdf_in%n_intp_r, &
-                     tmp_Cvec, 1, 0.d0, tmp_CvecM, 1)
+          call dgemv('N', n_intp_loc, isdf_in%n_intp_r, 1.d0, isdf_in%Mmtrx(intp_start, 1, 1, 1, 1, 1, 1), &
+                     isdf_in%n_intp_r, tmp_Cvec, 1, 0.d0, tmp_CvecM, 1)
           tmp_Cvec(1:isdf_in%n_intp_r) = 0.d0
           tmp_Cvec(intp_start:intp_end) = tmp_CvecM(1:n_intp_loc)
-          call mpi_allreduce(MPI_IN_PLACE, tmp_Cvec, isdf_in%n_intp_r, &
-                             MPI_DOUBLE, MPI_SUM, peinf%comm, info)
+          call mpi_allreduce(MPI_IN_PLACE, tmp_Cvec, isdf_in%n_intp_r, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
           if (peinf%master) print *, " inode ", w_grp%inode, "Mmtrx @ tmp_Cvec ", tmp_Cvec(1:10)
           ! Pvec stores the icv_start to icv_end elements of the global_Pvec
           ! compute Pvec(1:ncv_loc) = tmp_Cvec(1:isdf_in%n_intp_r)*tmp_Cmtrx(1:isdf_in%n_intp_r, 1:ncv_loc)
@@ -299,34 +281,28 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
           !endif
           Pvec(1:ncv_loc) = Pvec(1:ncv_loc)*sqrtR(1:ncv_loc)
           pnorm2 = ddot(ncv_loc, Pvec, 1, Pvec, 1)
-          call mpi_allreduce(MPI_IN_PLACE, pnorm2, 1, MPI_DOUBLE, &
-                             MPI_SUM, peinf%comm, info)
+          call mpi_allreduce(MPI_IN_PLACE, pnorm2, 1, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
           if (peinf%master) print *, "pnorm**2 ", pnorm2
           !stop
           if (jn <= nval) then ! occupied states
-            ezz(1:sig_in%nen) = &
-              -(zz(1:sig_in%nen) - kpt%wfn(isp, ik)%e1(jn)) &
-              + cmplx(0.d0, 1.d0)*ecuts
+            ezz(1:sig_in%nen) = -(zz(1:sig_in%nen) - kpt%wfn(isp, ik)%e1(jn)) + cmplx(0.d0, 1.d0)*ecuts
             ezz(sig_in%nen + 1) = cmplx(0.d0, 0.d0)
             ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
-            call lanczos_spectra_isdf(Pvec, sqrt(pnorm2), ncv_loc, ezz, sig_in%nen + 1, &
-                                      niter, isdf_in, kpt%wfn(isp, ik), tmp_Cmtrx, sqrtR, &
-                                      polynomial, npoly, sigma_corr_tmp)
+            call lanczos_spectra_isdf(Pvec, sqrt(pnorm2), ncv_loc, ezz, sig_in%nen + 1, niter, isdf_in, &
+                                      kpt%wfn(isp, ik), tmp_Cmtrx, sqrtR, polynomial, npoly, sigma_corr_tmp)
             sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + 2.0*pnorm2/(-ezz(1:sig_in%nen))* &
                                        (-sigma_corr_tmp(sig_in%nen + 1) + sigma_corr_tmp(1:sig_in%nen))
 #ifdef DEBUG
-            if (peinf%master) print *, "incr ", 2.0*pnorm2*(-sigma_corr_tmp(sig_in%nen + 1) + sigma_corr_tmp(2))/(-ezz(2))
+            if (peinf%master) print *, "incr ", 2.0*pnorm2* &
+              (-sigma_corr_tmp(sig_in%nen + 1) + sigma_corr_tmp(2))/(-ezz(2))
 #endif
             ! stop
           else ! for unoccupied states
-            ezz(1:sig_in%nen) = &
-              (zz(1:sig_in%nen) - kpt%wfn(isp, ik)%e1(jn)) &
-              + cmplx(0.d0, 1.d0)*ecuts
+            ezz(1:sig_in%nen) = (zz(1:sig_in%nen) - kpt%wfn(isp, ik)%e1(jn)) + cmplx(0.d0, 1.d0)*ecuts
             ezz(sig_in%nen + 1) = cmplx(0.d0, 0.d0)
             ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
-            call lanczos_spectra_isdf(Pvec, sqrt(pnorm2), ncv_loc, ezz, sig_in%nen + 1, &
-                                      niter, isdf_in, kpt%wfn(isp, ik), tmp_Cmtrx, sqrtR, &
-                                      polynomial, npoly, sigma_corr_tmp)
+            call lanczos_spectra_isdf(Pvec, sqrt(pnorm2), ncv_loc, ezz, sig_in%nen + 1, niter, isdf_in, &
+                                      kpt%wfn(isp, ik), tmp_Cmtrx, sqrtR, polynomial, npoly, sigma_corr_tmp)
             sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + 2.0*pnorm2/ezz(1:sig_in%nen)* &
                                        (-sigma_corr_tmp(sig_in%nen + 1) + sigma_corr_tmp(1:sig_in%nen))
 #ifdef DEBUG
@@ -365,8 +341,7 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
 
 23 continue
 
-  call stopwatch(r_grp%master, &
-                 ' All matrix elements calculated. Start printout')
+  call stopwatch(r_grp%master, ' All matrix elements calculated. Start printout')
 
   if (peinf%master .and. sig_in%xc == XC_GW) then
     open (12, file='hmat_qp_nostatic', form='formatted')
@@ -473,8 +448,7 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
       !
       ! Print self-energy tables without static correction.
       !
-      call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), &
-                      kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), 12, &
+      call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), 12, &
                       isp, ik, iord, qpmix, rtmp, file_name)
 
       deallocate (iord)
@@ -485,8 +459,7 @@ subroutine Zcalculate_sigma_lanczos(nspin, nkpt, &
     close (12)
   end if
 #ifdef MPI
-  call MPI_BCAST(max_sig, 1, MPI_DOUBLE_PRECISION, &
-                 peinf%masterid, peinf%comm, info)
+  call MPI_BCAST(max_sig, 1, MPI_DOUBLE_PRECISION, peinf%masterid, peinf%comm, info)
 #endif
 
   !-------------------------------------------------------------------

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -6,10 +6,9 @@
 ! Author: Weiwei Gao @ Dalian Univ. of Tech.
 !
 !---------------------------------------------------------------
-subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
-                                              sig_en, dft_code, gvec, kpt, qpt, k_c, k_p, sig_in, &
-                                              sig, q_p, nolda, tamm_d, writeqp, snorm, cohsex, &
-                                              ecuts, sig_cut, max_sig, isdf_in, doisdf, opt)
+subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gvec, kpt, qpt, k_c, k_p, sig_in, sig, &
+                                              q_p, nolda, tamm_d, writeqp, snorm, cohsex, ecuts, sig_cut, max_sig, &
+                                              isdf_in, doisdf, opt)
 
   use typedefs
   use mpi_module
@@ -75,19 +74,20 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
   integer :: ii, jj, irp, iq, ik, jk, isp, isig, info, neig_qp, ien, ic, iv, icv, jn, m1, inode, &
              myn_intp_start, myn_intp_end, myn_intp_r, jnend, npoly, ncond, nval, jnblock
   real(dp) :: tsec(2), rtmp, deltae, emin, emax, en0
-  real(dp), allocatable :: polynomial(:), Pvec(:, :), tmp_Cmtrx(:, :), &
-                           tmp_CvecM(:, :), tmp_poly(:), sqrtR(:), tmp_Cvec(:, :), tmparray(:, :)
+  real(dp), allocatable :: polynomial(:), Pvec(:, :), tmp_Cmtrx(:, :), tmp_CvecM(:, :), tmp_poly(:), sqrtR(:), &
+                           tmp_Cvec(:, :), tmparray(:, :)
   integer, allocatable :: iord(:) !, cvpair(:,:)
   integer, parameter :: it_scf = 0
   real(dp), parameter :: qpmix = 1.d0
   complex(dp), allocatable :: zz(:), ezz(:, :), sigma_corr(:), sigma_corr_tmp(:, :)
 
   ! -------- temporary arrays for lanczos iterations --------
-  integer :: irep, kk, blksz, iblk, cvstart, jc, jv, jvrep, jcrep, istart, ivstart, icstart, &
-             lncond, lnval, m1_rep, maxnblks, nmrep, ibnd, lrp1, lrp2, nx, nx_select, n_intp_r, icend
-  integer, allocatable :: blks(:, :, :), tmp_lrep(:, :), tmp_lvrep(:, :), &
-                          tmp_lcrep(:, :), nvblks(:), nblks(:), ncblks(:), tmp_count(:)
+  integer :: irep, kk, blksz, iblk, cvstart, jc, jv, jvrep, jcrep, istart, ivstart, icstart, lncond, lnval, m1_rep, &
+             maxnblks, nmrep, ibnd, lrp1, lrp2, nx, nx_select, n_intp_r, icend
+  integer, allocatable :: blks(:, :, :), tmp_lrep(:, :), tmp_lvrep(:, :), tmp_lcrep(:, :), nvblks(:), nblks(:), &
+                          ncblks(:), tmp_count(:)
   real(dp) :: pnorm2(opt%jnblock), pnorm(opt%jnblock), fit_error, max_fit_error
+  real(dp) :: occ ! eta_n in the paper, 1 for occupied and -1 for empty
   !real(dp) :: MC_vec(w_grp%myn_intp_r, opt%jnblock), &
   !  CMC_vec(w_grp%ldncv, opt%jnblock), &
   !  tmp_vec(isdf_in%n_intp_r, opt%jnblock)
@@ -102,9 +102,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
   real(dp), parameter :: d_one = 1.d0, d_zero = 0.d0
   type(c_ptr) :: d_PsiV, d_PsiC, d_Cmtrx, d_cvec, d_pvec, d_lcrep
   type(c_ptr) :: handle = c_null_ptr
-  integer(kind(HIPBLAS_OP_N)), parameter :: &
-    transt = HIPBLAS_OP_T, &
-    transn = HIPBLAS_OP_N
+  integer(kind(HIPBLAS_OP_N)), parameter :: transt = HIPBLAS_OP_T, transn = HIPBLAS_OP_N
   !integer :: ndevs, mydevice
   integer(c_size_t), parameter :: Bytes_double = 8
   integer(c_size_t) :: Nbytes
@@ -114,8 +112,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
   integer :: istat, vstep, voffset, v_incr_end, v_incr
   integer :: ndevs, mydev
   type(cublasHandle) :: handle
-  real(dp), device, dimension(:, :), allocatable :: d_PsiV, d_PsiC, d_Cmtrx, &
-                                                    d_cvec, d_pvec
+  real(dp), device, dimension(:, :), allocatable :: d_PsiV, d_PsiC, d_Cmtrx, d_cvec, d_pvec
   integer, device, dimension(:), allocatable :: d_lcrep
   integer(kind=cuda_stream_kind) :: streamid
 #endif
@@ -186,9 +183,9 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
     do isp = 1, nspin
       jk = sig(isp, ik)%indxk
       call timacc(6, 1, tsec)
-      if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. &
-          sig_in%xc == XC_B3LYP) &
+      if (sig_in%xc == XC_GW .or. sig_in%xc == XC_HF .or. sig_in%xc == XC_B3LYP) then
         call Zfock_exchange(gvec, kpt, sig(isp, ik), isp, jk)
+      end if
       call timacc(6, 2, tsec)
     end do ! isp
   end do ! ik
@@ -271,8 +268,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
         end do ! nx
         deallocate (tmp_poly)
       end if
-      if (peinf%master) print *, "Use ", nx_select, &
-        " points to fit polynomial. Relative error: ", fit_error
+      if (peinf%master) print *, "Use ", nx_select, " points to fit polynomial. Relative error: ", fit_error
       !if (peinf%master) print *, "polynomial ", polynomial(1:(npoly+1))
     end if ! tamm_d
     call MPI_BCAST(polynomial, npoly + 1, MPI_DOUBLE, peinf%masterid, peinf%comm, ii)
@@ -396,10 +392,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
     isdf_in%mync_sym = 0
     isdf_in%mynv_sym = 0
     do irep = 1, gvec%syms%ntrans
-      isdf_in%mync_sym(irep) = isdf_in%lcrep_bound(irep, 2) &
-                               - isdf_in%lcrep_bound(irep, 1) + 1
-      isdf_in%mynv_sym(irep) = isdf_in%lvrep_bound(irep, 2) &
-                               - isdf_in%lvrep_bound(irep, 1) + 1
+      isdf_in%mync_sym(irep) = isdf_in%lcrep_bound(irep, 2) - isdf_in%lcrep_bound(irep, 1) + 1
+      isdf_in%mynv_sym(irep) = isdf_in%lvrep_bound(irep, 2) - isdf_in%lvrep_bound(irep, 1) + 1
     end do ! irep
     do irep = 1, gvec%syms%ntrans
 
@@ -418,8 +412,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
 
       end do ! lrp1
     end do ! irep
-    call MPI_ALLREDUCE(isdf_in%myncv_sym, tmp_count, gvec%syms%ntrans, &
-                       MPI_INTEGER, MPI_SUM, peinf%comm, info)
+    call MPI_ALLREDUCE(isdf_in%myncv_sym, tmp_count, gvec%syms%ntrans, MPI_INTEGER, MPI_SUM, peinf%comm, info)
     !do ipe = 0, peinf%npes-1
     !  if (peinf%inode .eq. ipe) then
     !    print *, " inode ", peinf%inode
@@ -459,9 +452,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
     vstep = 12000**2/isdf_in%maxmync_sym/isdf_in%n_intp_r
     if (vstep <= 0) vstep = 1
     if (vstep > isdf_in%maxmynv_sym) vstep = isdf_in%maxmynv_sym
-    if (peinf%master) print *, " vstep ", vstep, " maxmync_sym ", &
-      isdf_in%maxmync_sym, " n_intp_r ", isdf_in%n_intp_r, " maxmynv_sym ", &
-      isdf_in%maxmynv_sym
+    if (peinf%master) print *, " vstep ", vstep, " maxmync_sym ", isdf_in%maxmync_sym, " n_intp_r ", &
+        isdf_in%n_intp_r, " maxmynv_sym ", isdf_in%maxmynv_sym
     allocate (tmparray(vstep*isdf_in%maxmync_sym, jnblock))
 #else
     allocate (tmparray(isdf_in%maxmync_sym, jnblock))
@@ -475,12 +467,9 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
     call hipCheck(hipMalloc(d_pvec, sizeof(tmparray))) ! mync, jnblock
     call hipCheck(hipMalloc(d_lcrep, sizeof(isdf_in%lcrep)))
     ! copy PsiV_intp_bl, PsiC_intp_bl and vec to device
-    call hipCheck(hipMemcpy(d_PsiV, c_loc(isdf_in%PsiV_intp_bl), &
-                            sizeof(isdf_in%PsiV_intp_bl), hipMemcpyHostToDevice))
-    call hipCheck(hipMemcpy(d_PsiC, c_loc(isdf_in%PsiC_intp_bl), &
-                            sizeof(isdf_in%PsiC_intp_bl), hipMemcpyHostToDevice))
-    call hipCheck(hipMemcpy(d_lcrep, c_loc(isdf_in%lcrep), &
-                            sizeof(isdf_in%lcrep), hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_PsiV, c_loc(isdf_in%PsiV_intp_bl), sizeof(isdf_in%PsiV_intp_bl), hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_PsiC, c_loc(isdf_in%PsiC_intp_bl), sizeof(isdf_in%PsiC_intp_bl), hipMemcpyHostToDevice))
+    call hipCheck(hipMemcpy(d_lcrep, c_loc(isdf_in%lcrep), sizeof(isdf_in%lcrep), hipMemcpyHostToDevice))
 #elif defined _CUDA
     allocate (d_PsiV, source=isdf_in%PsiV_intp_bl(:, :, 1, 1))
     allocate (d_PsiC, source=isdf_in%PsiC_intp_bl(:, :, 1, 1))
@@ -579,9 +568,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
             do iblk = 1, nblks(irep)
               if (peinf%master) then
                 write (6, '(/,a)') repeat('-', 65)
-                write (*, '(6(a,i0))') " ik = ", ik, "/", nkpt, "   isp = ", isp, "/", nspin, &
-                  "   isig = ", isig, "/", sig_in%ndiag
-                write (*, '(4(a,i0))') " irep = ", irep, "/", gvec%syms%ntrans, "   iblk = ", iblk, "/",  nblks(irep)
+                write (6, '(10(a,i0))') " ik: ", ik, "/", nkpt, "   isp: ", isp, "/", nspin, "   isig: ", isig, &
+                  "/", sig_in%ndiag, "   irep: ", irep, "/", gvec%syms%ntrans, "   iblk: ", iblk, "/",  nblks(irep)
               end if
               ! ----------------------------------------------------------------
               ! prepare vector |P_mn>
@@ -612,8 +600,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                   isdf_in%Psi_intp_loc(1:myn_intp_r, jk, 1, 1)
               end do ! kk
               !if (w_grp%npes .gt. 1) then
-              call MPI_ALLREDUCE(MPI_IN_PLACE, tmp_Cvec, &
-                                 isdf_in%n_intp_r*blksz, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
+              call MPI_ALLREDUCE(MPI_IN_PLACE, tmp_Cvec, isdf_in%n_intp_r*blksz, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
               !endif
               !if (w_grp%master) print *, "tmp_Cvec", tmp_Cvec(1:10, 1), "nmrep", nmrep
               ! Compute tmp_CvecM(1:n_intp_loc)
@@ -627,10 +614,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                          isdf_in%Mmtrx_loc(1, 1, 1, 1, 1, 1, nmrep), myn_intp_r, tmp_Cvec, &
                          isdf_in%n_intp_r, 0.d0, tmp_CvecM, myn_intp_r)
               tmp_Cvec = 0.d0
-              tmp_Cvec(myn_intp_start:myn_intp_end, 1:blksz) = &
-                tmp_CvecM(1:myn_intp_r, 1:blksz)
-              call MPI_ALLREDUCE(MPI_IN_PLACE, tmp_Cvec, &
-                                 isdf_in%n_intp_r*blksz, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
+              tmp_Cvec(myn_intp_start:myn_intp_end, 1:blksz) = tmp_CvecM(1:myn_intp_r, 1:blksz)
+              call MPI_ALLREDUCE(MPI_IN_PLACE, tmp_Cvec, isdf_in%n_intp_r*blksz, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
               !if (peinf%master) print *, "  tmp_CvecM(:, 1) ", tmp_Cvec(1:10, 1)
               !if (peinf%master) print *, "  tmp_CvecM(:, 1) ", tmp_Cvec(1:10, 2)
               ! Pvec stores the icv_start to icv_end elements of the global_Pvec
@@ -642,8 +627,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
               v_incr = 0
 #endif
               do jvrep = 1, gvec%syms%ntrans
-                do iv = isdf_in%lvrep_bound(jvrep, 1), &
-                  isdf_in%lvrep_bound(jvrep, 2)
+                do iv = isdf_in%lvrep_bound(jvrep, 1), isdf_in%lvrep_bound(jvrep, 2)
                   jv = isdf_in%lvrep(iv)
 #ifdef _CUDA
                   if (v_incr == 0) then
@@ -662,18 +646,15 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                   Nbytes = isdf_in%n_intp_r*blksz*Bytes_double
                   call hipCheck(hipMemcpy(d_cvec, c_loc(tmp_Cvec), Nbytes,
                   hipMemcpyHostToDevice))
-                  call hadamard_prod_mat_sym(d_PsiV, d_PsiC, d_Cmtrx, d_lcrep, &
-                                             isdf_in%n_intp_r, jv - 1, isdf_in%mynv, isdf_in%mync, &
-                                             isdf_in%maxmync_sym, isdf_in%lcrep_bound(jcrep, 1),
-                  isdf_in%lcrep_bound(jcrep, 2))
-                  call hipblasCheck(hipblasDgemm(handle, transt, transn, &
-                                                 isdf_in%mync_sym(jcrep), blksz, isdf_in%n_intp_r, d_one, &
-                                                 d_Cmtrx, isdf_in%n_intp_r, d_cvec, isdf_in%n_intp_r, &
-                                                 d_zero, d_pvec, isdf_in%maxmync_sym))
+                  call hadamard_prod_mat_sym(d_PsiV, d_PsiC, d_Cmtrx, d_lcrep, isdf_in%n_intp_r, jv - 1, isdf_in%mynv, &
+                                             isdf_in%mync, isdf_in%maxmync_sym, isdf_in%lcrep_bound(jcrep, 1), &
+                                             isdf_in%lcrep_bound(jcrep, 2))
+                  call hipblasCheck(hipblasDgemm(handle, transt, transn, isdf_in%mync_sym(jcrep), blksz, &
+                                                 isdf_in%n_intp_r, d_one, d_Cmtrx, isdf_in%n_intp_r, d_cvec, &
+                                                 isdf_in%n_intp_r, d_zero, d_pvec, isdf_in%maxmync_sym))
                   call hipCheck(hipDeviceSynchronize())
                   Nbytes = isdf_in%maxmync_sym*blksz*Bytes_double
-                  call hipCheck(hipMemcpy(c_loc(tmparray), d_pvec, Nbytes, &
-                                          hipMemcpyDeviceToHost))
+                  call hipCheck(hipMemcpy(c_loc(tmparray), d_pvec, Nbytes, hipMemcpyDeviceToHost))
 #elif defined _CUDA
                   d_cvec = tmp_Cvec
                   icstart = isdf_in%lcrep_bound(jcrep, 1)
@@ -683,15 +664,12 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
 !$cuf kernel do
                   do ic = icstart, icend
                     jc = d_lcrep(ic)
-                    d_Cmtrx(voffset + ic - icstart + 1, 1:n_intp_r) = &
-                      d_PsiC(1:n_intp_r, jc)*d_PsiV(1:n_intp_r, jv)
+                    d_Cmtrx(voffset + ic - icstart + 1, 1:n_intp_r) = d_PsiC(1:n_intp_r, jc)*d_PsiV(1:n_intp_r, jv)
                   end do ! ic
 
                   if (v_incr == v_incr_end) then
-                    call cublasdgemm('N', 'N', &
-                                     v_incr_end*isdf_in%mync_sym(jcrep), blksz, n_intp_r, &
-                                     1.d0, d_Cmtrx, vstep*isdf_in%maxmync_sym, d_Cvec, &
-                                     isdf_in%n_intp_r, 0.d0, d_pvec, &
+                    call cublasdgemm('N', 'N', v_incr_end*isdf_in%mync_sym(jcrep), blksz, n_intp_r, 1.d0, d_Cmtrx, &
+                                     vstep*isdf_in%maxmync_sym, d_Cvec, isdf_in%n_intp_r, 0.d0, d_pvec, &
                                      vstep*isdf_in%maxmync_sym)
                     v_incr = 0
                     tmparray = d_pvec
@@ -701,18 +679,14 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                   end if
                   istat = cudaDeviceSynchronize()
 #else
-                  do ic = isdf_in%lcrep_bound(jcrep, 1), &
-                    isdf_in%lcrep_bound(jcrep, 2)
+                  do ic = isdf_in%lcrep_bound(jcrep, 1), isdf_in%lcrep_bound(jcrep, 2)
                     jc = isdf_in%lcrep(ic)
-                    tmp_Cmtrx(ic - isdf_in%lcrep_bound(jcrep, 1) + 1, &
-                              1:isdf_in%n_intp_r) = &
+                    tmp_Cmtrx(ic - isdf_in%lcrep_bound(jcrep, 1) + 1, 1:isdf_in%n_intp_r) = &
                       isdf_in%PsiC_intp_bl(1:isdf_in%n_intp_r, jc, 1, 1)* &
                       isdf_in%PsiV_intp_bl(1:isdf_in%n_intp_r, jv, 1, 1)
                   end do ! ic loop
-                  call dgemm('N', 'N', isdf_in%mync_sym(jcrep), blksz, &
-                             isdf_in%n_intp_r, 1.d0, tmp_Cmtrx, isdf_in%maxmync_sym, &
-                             tmp_Cvec, isdf_in%n_intp_r, 0.d0, tmparray, &
-                             isdf_in%maxmync_sym)
+                  call dgemm('N', 'N', isdf_in%mync_sym(jcrep), blksz, isdf_in%n_intp_r, 1.d0, tmp_Cmtrx, &
+                             isdf_in%maxmync_sym, tmp_Cvec, isdf_in%n_intp_r, 0.d0, tmparray, isdf_in%maxmync_sym)
 #endif
 
 #ifndef _CUDA
@@ -745,17 +719,16 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                   Pvec(1:isdf_in%myncv_sym(nmrep), kk) = &
                     Pvec(1:isdf_in%myncv_sym(nmrep), kk)*sqrtR(1:isdf_in%myncv_sym(nmrep))
                 end if
-                pnorm2(kk) = ddot(isdf_in%myncv_sym(nmrep), Pvec(1, kk), 1, &
-                                  Pvec(1, kk), 1)
+                pnorm2(kk) = ddot(isdf_in%myncv_sym(nmrep), Pvec(1, kk), 1, Pvec(1, kk), 1)
               end do ! kk
-              call MPI_ALLREDUCE(MPI_IN_PLACE, pnorm2, blksz, MPI_DOUBLE, &
-                                 MPI_SUM, peinf%comm, info)
+              call MPI_ALLREDUCE(MPI_IN_PLACE, pnorm2, blksz, MPI_DOUBLE, MPI_SUM, peinf%comm, info)
               do kk = 1, blksz
                 pnorm(kk) = sqrt(pnorm2(kk))
               end do ! kk
               call stopwatch(peinf%master, " Finished preparing Pvec ")
               !if (w_grp%master) print *, "pnorm**2 ", pnorm2(1:blksz)
               !stop
+
               if (blks(iblk, 3, irep) == 1) then ! occupied states
 
                 do kk = 1, blksz
@@ -766,8 +739,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                 ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
                 call lanczos_spectra_isdf_lowcomsym(Pvec, pnorm, isdf_in%myncv_sym(nmrep), ezz, sig_in%nen + 1, &
                                                     opt%lanczos_niter, isdf_in, sqrtR, polynomial, npoly, &
-                                                    sigma_corr_tmp, tamm_d, &
-                                                    blksz, nmrep, gvec &
+                                                    sigma_corr_tmp, tamm_d, blksz, nmrep, gvec &
 #ifdef DCU
                                                     , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, d_cvec, d_lcrep, &
                                                     handle &
@@ -791,8 +763,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
 #ifdef DEBUG
                   if (peinf%master) then
                     if (tamm_d) then
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        -sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
+                      print *, isdf_in%lrep(jn + kk - 1), "incr ", -sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
                       do ien = 1, sig_in%nen
                         write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
                           m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
@@ -800,8 +771,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                       end do ! ien
                     else
                       print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))* &
-                          2.0*pnorm2(kk)/ezz(2, kk)
+                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))*2.0*pnorm2(kk)/ezz(2, kk)
                       do ien = 1, sig_in%nen
                         write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
                           m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
@@ -823,8 +793,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                 ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
                 call lanczos_spectra_isdf_lowcomsym(Pvec, pnorm, isdf_in%myncv_sym(nmrep), ezz, sig_in%nen + 1, &
                                                     opt%lanczos_niter, isdf_in, sqrtR, polynomial, npoly, &
-                                                    sigma_corr_tmp, tamm_d, &
-                                                    blksz, nmrep, gvec &
+                                                    sigma_corr_tmp, tamm_d, blksz, nmrep, gvec &
 #ifdef DCU
                                                     , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, &
                                                     d_cvec, d_lcrep, handle &
@@ -847,8 +816,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
 #ifdef DEBUG
                   if (peinf%master) then
                     if (tamm_d) then
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
+                      print *, isdf_in%lrep(jn + kk - 1), "incr ", sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
                       do ien = 1, sig_in%nen
                         write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
                           m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
@@ -856,8 +824,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
                       end do ! ien
                     else
                       print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))* &
-                          2.0*pnorm2(kk)/ezz(2, kk)
+                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))*2.0*pnorm2(kk)/ezz(2, kk)
                       do ien = 1, sig_in%nen
                         write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
                           m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
@@ -882,16 +849,13 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
             write (6, '(a)') repeat('-', 65)
             print *, "sigma_corr", sig_in%map(sig_in%diag(isig))
             do ien = 1, sig_in%nen
-              write (6, '(a,i7,f15.6,f15.6,f15.6)') " #sigma_c ", ien, &
-                ryd*(deltae*(ien - 1) + en0), real(sigma_corr(ien))*ryd, &
-                aimag(sigma_corr(ien))*ryd
+              write (6, '(a,i7,f15.6,f15.6,f15.6)') " #sigma_c ", ien, ryd*(deltae*(ien - 1) + en0), &
+                  real(sigma_corr(ien))*ryd, aimag(sigma_corr(ien))*ryd
             end do ! ien
             print *, "E_qp(E)", sig_in%map(sig_in%diag(isig))
             do ien = 1, sig_in%nen
-              write (6, '(a,i7,f15.6,f15.6)') " #E_qp ", ien, &
-                ryd*(deltae*(ien - 1) + en0), &
-                (kpt%wfn(1, 1)%e1(m1) + real(sig(1, 1)%xdiag(isig) &
-                                             + sigma_corr(ien) - sig(1, 1)%vxcdiag(isig)))*ryd
+              write (6, '(a,i7,f15.6,f15.6)') " #E_qp ", ien, ryd*(deltae*(ien - 1) + en0), &
+                (kpt%wfn(1, 1)%e1(m1) + real(sig(1, 1)%xdiag(isig) + sigma_corr(ien) - sig(1, 1)%vxcdiag(isig)))*ryd
             end do ! ien
           end if ! peinf%master
           do ien = 1, sig_in%nen
@@ -948,8 +912,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
   if (peinf%master) close (dbgunit)
 #endif
 
-  call stopwatch(r_grp%master, &
-                 ' All matrix elements calculated. Start printout')
+  call stopwatch(r_grp%master, ' All matrix elements calculated. Start printout')
 
   if (peinf%master .and. sig_in%xc == XC_GW) then
     open (12, file='hmat_qp_nostatic', form='formatted')
@@ -1035,37 +998,30 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, &
       !
       if (gvec%per > 0) then
         if (nspin == 1) then
-          write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_', ik, '_', &
-            it_scf
+          write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_', ik, '_', it_scf
         else
           if (isp == 1) then
-            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_up_', ik, &
-              '_', it_scf
+            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_up_', ik, '_', it_scf
           else
-            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_down_', ik, &
-              '_', it_scf
+            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_down_', ik, '_', it_scf
           end if
         end if
       else
         if (nspin == 1) then
-          write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_', ik, '_', &
-            it_scf
+          write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_', ik, '_', it_scf
         else
           if (isp == 1) then
-            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_up_', ik, &
-              '_', it_scf
+            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_up_', ik, '_', it_scf
           else
-            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_down_', ik, &
-              '_', it_scf
+            write (file_name, '(a,i3.3,a,i4.4)') 'sigma_nostatic_down_', ik, '_', it_scf
           end if
         end if
       end if
       !
       ! Print self-energy tables without static correction.
       !
-      call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), kpt%wfn(isp, jk), &
-                      q_p(1:gvec%syms%ntrans, isp, ik), 12, isp, ik, iord, qpmix, rtmp, &
-                      file_name)
+      call printsigma(gvec%syms%ntrans, sig_in, sig(isp, ik), kpt%wfn(isp, jk), q_p(1:gvec%syms%ntrans, isp, ik), 12, &
+                      isp, ik, iord, qpmix, rtmp, file_name)
 
       deallocate (iord)
     end do ! isp

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -506,7 +506,6 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         occ(lnval/jnblock+1, irep) = lnval-lnval/jnblock*jnblock
       end if
 
-      write (*, *)
       if (w_grp%master) then
         write (*, "(A)") repeat('-', 65)
         write (*, "(2(A, I0))") " irep: ", irep, "/", gvec%syms%ntrans

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -72,7 +72,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
 
   logical :: staticcorr
   integer :: ii, jj, irp, iq, ik, jk, isp, isig, info, neig_qp, ien, ic, iv, icv, jn, m1, inode, &
-             myn_intp_start, myn_intp_end, myn_intp_r, jnend, npoly, ncond, nval, jnblock
+             myn_intp_start, myn_intp_end, myn_intp_r, npoly, ncond, nval, jnblock
   real(dp) :: tsec(2), rtmp, deltae, emin, emax, en0
   real(dp), allocatable :: polynomial(:), Pvec(:, :), tmp_Cmtrx(:, :), tmp_CvecM(:, :), tmp_poly(:), sqrtR(:), &
                            tmp_Cvec(:, :), tmparray(:, :)
@@ -82,12 +82,12 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
   complex(dp), allocatable :: zz(:), ezz(:, :), sigma_corr(:), sigma_corr_tmp(:, :)
 
   ! -------- temporary arrays for lanczos iterations --------
-  integer :: irep, kk, blksz, iblk, cvstart, jc, jv, jvrep, jcrep, istart, ivstart, icstart, lncond, lnval, m1_rep, &
+  integer :: irep, kk, blksz, iblk, cvstart, jc, jv, jvrep, jcrep, istart, ivstart, icstart, ln, lnval, m1_rep, &
              maxnblks, nmrep, ibnd, lrp1, lrp2, nx, nx_select, n_intp_r, icend
-  integer, allocatable :: blks(:, :, :), tmp_lrep(:, :), tmp_lvrep(:, :), tmp_lcrep(:, :), nvblks(:), nblks(:), &
-                          ncblks(:), tmp_count(:)
+  integer, allocatable :: blks(:, :, :), tmp_lrep(:, :), tmp_lvrep(:, :), tmp_lcrep(:, :), nblks(:), tmp_count(:), &
+                          occ(:, :)
   real(dp) :: pnorm2(opt%jnblock), pnorm(opt%jnblock), fit_error, max_fit_error
-  real(dp) :: occ ! eta_n in the paper, 1 for occupied and -1 for empty
+  real(dp), allocatable :: eta(:)  ! eta_n in the paper, 1 for occupied and -1 for empty, (ib)
   !real(dp) :: MC_vec(w_grp%myn_intp_r, opt%jnblock), &
   !  CMC_vec(w_grp%ldncv, opt%jnblock), &
   !  tmp_vec(isdf_in%n_intp_r, opt%jnblock)
@@ -214,8 +214,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
 #endif
 
   if (sig_in%xc == XC_GW) then
-    ! deallocate unused arrays
 
+    ! deallocate unused arrays
     do iq = 1, qpt%nk
       do irp = 1, gvec%syms%ntrans
         !deallocate(k_p(irp,iq)%col)
@@ -447,6 +447,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     allocate (tmp_CvecM(myn_intp_r, jnblock))
     allocate (sqrtR(isdf_in%maxmyncv_sym))
     allocate (tmp_Cmtrx(isdf_in%maxmync_sym, isdf_in%n_intp_r))
+    allocate (eta(jnblock))
 
 #ifdef _CUDA
     vstep = 12000**2/isdf_in%maxmync_sym/isdf_in%n_intp_r
@@ -479,56 +480,37 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     allocate (d_pvec(isdf_in%maxmync_sym*vstep, jnblock))
 #endif
 
-    allocate (nvblks(gvec%syms%ntrans))
-    allocate (ncblks(gvec%syms%ntrans))
     allocate (nblks(gvec%syms%ntrans))
     do irep = 1, gvec%syms%ntrans
-      lnval = isdf_in%lrep_bound(irep, 3) - isdf_in%lrep_bound(irep, 1) + 1
-      nvblks(irep) = lnval/jnblock
-      if (mod(lnval, jnblock) > 0) nvblks(irep) = nvblks(irep) + 1
-      lncond = isdf_in%lrep_bound(irep, 2) - isdf_in%lrep_bound(irep, 3)
-      ncblks(irep) = lncond/jnblock
-      if (mod(lncond, jnblock) > 0) ncblks(irep) = ncblks(irep) + 1
-      !print *, ncblks
-      nblks(irep) = ncblks(irep) + nvblks(irep)
+      ln = isdf_in%lrep_bound(irep, 2) - isdf_in%lrep_bound(irep, 1) + 1
+      nblks(irep) = (ln-1)/jnblock+1  ! ceiling division
     end do ! irep
     maxnblks = maxval(nblks)
-    allocate (blks(maxnblks, 3, irep))
+
+    allocate (occ(maxnblks, gvec%syms%ntrans))
+    allocate (blks(maxnblks, 2, gvec%syms%ntrans))
+    occ = 0
     blks = 0
     ! blks(kk, 1, irep) : start index of isdf_in%lrep
     ! blks(kk, 2, irep) : end index of isdf_in%lrep
     do irep = 1, gvec%syms%ntrans
+      ln = isdf_in%lrep_bound(irep, 2) - isdf_in%lrep_bound(irep, 1) + 1
       lnval = isdf_in%lrep_bound(irep, 3) - isdf_in%lrep_bound(irep, 1) + 1
-      lncond = isdf_in%lrep_bound(irep, 2) - isdf_in%lrep_bound(irep, 3)
-      if (nvblks(irep) >= 1) then
-        do kk = 1, lnval/jnblock
-          blks(kk, 1, irep) = (kk - 1)*jnblock + 1
-          blks(kk, 2, irep) = kk*jnblock
-          blks(kk, 3, irep) = 1
-        end do ! kk
+      do iblk = 1, nblks(irep)
+        blks(iblk, 1, irep) = (iblk-1)*jnblock + 1
+        blks(iblk, 2, irep) = iblk*jnblock
+      end do
+      blks(nblks(irep), 2, irep) = ln
+      occ(1:lnval/jnblock, irep) = jnblock
+      if (lnval/jnblock < nblks(irep)) then
+        occ(lnval/jnblock+1, irep) = lnval-lnval/jnblock*jnblock
       end if
-      if (mod(lnval, jnblock) > 0) then
-        blks(nvblks(irep), 1, irep) = (nvblks(irep) - 1)*jnblock + 1
-        blks(nvblks(irep), 2, irep) = lnval
-        blks(nvblks(irep), 3, irep) = 1
-      end if
-      if (ncblks(irep) >= 1) then
-        do kk = 1, lncond/jnblock
-          blks(nvblks(irep) + kk, 1, irep) = lnval + (kk - 1)*jnblock + 1
-          blks(nvblks(irep) + kk, 2, irep) = lnval + kk*jnblock
-          blks(nvblks(irep) + kk, 3, irep) = 0
-        end do ! kk
-      end if
-      if (mod(lncond, jnblock) > 0) then
-        blks(nblks(irep), 1, irep) = lnval + (ncblks(irep) - 1)*jnblock + 1
-        blks(nblks(irep), 2, irep) = lnval + lncond
-        blks(nblks(irep), 3, irep) = 0
-      end if
+
       if (w_grp%master) then
-        write (*, "(3(A, I0))") " irep = ", irep, "  nvblks = ", nvblks(irep), "  ncblks = ", ncblks(irep)
-        write (*, *) "  idx   blks "
+        write (*, "(2(A, I0))") " irep = ", irep, "  nblks = ", nblks(irep)
+        write (*, "(A)") "   idx     blks     occ"
         do kk = 1, nblks(irep)
-          write (*, *) kk, blks(kk, 1:3, irep)
+          write (*, "(4I6)") kk, blks(kk, 1:2, irep), occ(kk, irep)
         end do ! kk
       end if
     end do ! irep
@@ -565,6 +547,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
                 end do ! ic
               end do ! iv loop
             end do ! jvrep loop
+
             do iblk = 1, nblks(irep)
               if (peinf%master) then
                 write (6, "(/, A)") repeat('-', 65)
@@ -589,8 +572,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
               ! m1 is the index of states which GW energy is calculated
               ! jn is sum over bands
               jn = blks(iblk, 1, irep) + isdf_in%lrep_bound(irep, 1) - 1
-              jnend = blks(iblk, 2, irep) + isdf_in%lrep_bound(irep, 1) - 1
-              blksz = jnend - jn + 1
+              blksz = blks(iblk, 2, irep) - blks(iblk, 1, irep) + 1
               call stopwatch(peinf%master, " Initializing Pvec")
               tmp_Cvec = 0.d0
               do kk = 1, blksz
@@ -726,15 +708,13 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
               end do ! kk
 
               call stopwatch(peinf%master, " Running Lanczos solver")
-              if (blks(iblk, 3, irep) == 1) then ! occupied states
-                occ = 1.d0
-              else ! unoccupied states
-                occ = -1.d0
-              end if
+              ! set eta for occupied and unoccupied states
+              eta = -1.d0
+              eta(1:occ(iblk, irep)) = 1.d0
 
               do kk = 1, blksz
                 jk = isdf_in%lrep(jn + kk - 1)
-                ezz(1:sig_in%nen, kk) = (-zz(1:sig_in%nen) + kpt%wfn(isp, ik)%e1(jk)) * occ + cmplx(0.d0, 1.d0)*ecuts
+                ezz(1:sig_in%nen, kk) = (-zz(1:sig_in%nen)+kpt%wfn(isp, ik)%e1(jk))*eta(kk) + cmplx(0.d0, 1.d0)*ecuts
               end do ! kk
               ezz(sig_in%nen + 1, 1:blksz) = cmplx(0.d0, 0.d0)
 
@@ -754,14 +734,13 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
               call stopwatch(peinf%master, " Summing over bands")
               do kk = 1, blksz
                 if (tamm_d) then
-                  ! TODO: Check if factor 2 is correct in sigma_corr adjustment
-                  sigma_corr_tmp(1:sig_in%nen, kk) = -sigma_corr_tmp(1:sig_in%nen, kk)*occ*2.0*pnorm2(kk)
+                  ! TODO: Check if factor sqrt(2) is correct in sigma_corr adjustment
+                  sigma_corr_tmp(1:sig_in%nen, kk) = -sigma_corr_tmp(1:sig_in%nen, kk)*eta(kk)*2.0**0.5*pnorm2(kk)
                 else
                   sigma_corr_tmp(1:sig_in%nen, kk) = (sigma_corr_tmp(sig_in%nen + 1, kk) &
                                                       -sigma_corr_tmp(1:sig_in%nen, kk)) &
-                                                     *occ*2.0*pnorm2(kk)/ezz(1:sig_in%nen, kk)
+                                                     *eta(kk)*2.0*pnorm2(kk)/ezz(1:sig_in%nen, kk)
                 end if
-                ! TODO: Check if factor 2 is correct in sigma_corr adjustment
                 sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + sigma_corr_tmp(1:sig_in%nen, kk)
 #ifdef DEBUG
                 if (peinf%master) then
@@ -803,6 +782,9 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     deallocate (tmp_Cvec)
     deallocate (tmp_CvecM)
     deallocate (sqrtR)
+    deallocate (eta)
+    deallocate (occ)
+    deallocate (blks)
     !deallocate (MC_vec)
     !deallocate (CMC_vec)
     !deallocate (tmp_vec)

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -506,9 +506,10 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         occ(lnval/jnblock+1, irep) = lnval-lnval/jnblock*jnblock
       end if
 
+      write (*, *)
       if (w_grp%master) then
-        write (6, "(/, A)") repeat('-', 65)
-        write (*, "(2(A, I0))") " irep: ", irep, "/", nblks(irep)
+        write (*, "(A)") repeat('-', 65)
+        write (*, "(2(A, I0))") " irep: ", irep, "/", gvec%syms%ntrans
         write (*, "(A)") "   iblk   blks(start, end)   occ"
         do iblk = 1, nblks(irep)
           write (*, "(4I8)") iblk, blks(iblk, 1:2, irep), occ(iblk, irep)

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -72,7 +72,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
 
   logical :: staticcorr
   integer :: ii, jj, irp, iq, ik, jk, isp, isig, info, neig_qp, ien, ic, iv, icv, jn, m1, inode, &
-             myn_intp_start, myn_intp_end, myn_intp_r, npoly, ncond, nval, jnblock
+             myn_intp_start, myn_intp_end, myn_intp_r, npoly, ncond, nval, nbnd, jnblock
   real(dp) :: tsec(2), rtmp, deltae, emin, emax, en0
   real(dp), allocatable :: polynomial(:), Pvec(:, :), tmp_Cmtrx(:, :), tmp_CvecM(:, :), tmp_poly(:), sqrtR(:), &
                            tmp_Cvec(:, :), tmparray(:, :)
@@ -507,10 +507,11 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
       end if
 
       if (w_grp%master) then
-        write (*, "(2(A, I0))") " irep = ", irep, "  nblks = ", nblks(irep)
-        write (*, "(A)") "   idx     blks     occ"
-        do kk = 1, nblks(irep)
-          write (*, "(4I6)") kk, blks(kk, 1:2, irep), occ(kk, irep)
+        write (6, "(/, A)") repeat('-', 65)
+        write (*, "(2(A, I0))") " irep: ", irep, "/", nblks(irep)
+        write (*, "(A)") "   iblk   blks(start, end)   occ"
+        do iblk = 1, nblks(irep)
+          write (*, "(4I8)") iblk, blks(iblk, 1:2, irep), occ(iblk, irep)
         end do ! kk
       end if
     end do ! irep
@@ -790,10 +791,6 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     !deallocate (tmp_vec)
     deallocate (isdf_in%PsiV_intp_bl)
     deallocate (isdf_in%PsiC_intp_bl)
-    deallocate (isdf_in%vstart)
-    deallocate (isdf_in%cstart)
-    deallocate (isdf_in%vend)
-    deallocate (isdf_in%cend)
     deallocate (tmparray)
     deallocate (tmp_count)
 

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -293,6 +293,14 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     !  k_p(1,1)%col(1:2, mycv_start:mycv_end)
     ! local number of interpolation points
     ! prepare indices for symmetry representations
+    if (peinf%master) then
+      write (*, "(A, F0.2, A)") "  tmp_lrep: ", 1.d0 * kpt%wfn(1, 1)%nmem * gvec%syms%ntrans / 2**17, " MB"
+      write (*, "(A, F0.2, A)") "  tmp_lvrep: ", 1.d0 * isdf_in%mynv * gvec%syms%ntrans / 2**17, " MB"
+      write (*, "(A, F0.2, A)") "  tmp_lcrep: ", 1.d0 * isdf_in%mync * gvec%syms%ntrans / 2**17, " MB"
+      write (*, "(A, F0.2, A)") "  isdf_in%lrep: ", 1.d0 * kpt%wfn(1, 1)%nmem / 2**17, " MB"
+      write (*, "(A, F0.2, A)") "  isdf_in%lvrep: ", 1.d0 * isdf_in%mynv / 2**17, " MB"
+      write (*, "(A, F0.2, A)") "  isdf_in%lcrep: ", 1.d0 * isdf_in%mync / 2**17, " MB"
+    end if
     allocate (tmp_lrep(kpt%wfn(1, 1)%nmem, gvec%syms%ntrans))
     allocate (tmp_lvrep(isdf_in%mynv, gvec%syms%ntrans))
     allocate (tmp_lcrep(isdf_in%mync, gvec%syms%ntrans))
@@ -351,7 +359,6 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     ! isdf_in%lcrep( lcrep_bound(1,irp):lvrep_bound(2,irp) ): 
     !   the index of states of representation irp, PsiC_intp_bl(n_intp_r, mync)
     do irp = 1, gvec%syms%ntrans
-
       if (irp == 1) then
         istart = 0
         ivstart = 0
@@ -383,11 +390,9 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     deallocate (tmp_lrep)
     deallocate (tmp_lvrep)
     deallocate (tmp_lcrep)
-    allocate (isdf_in%ncv_sym(gvec%syms%ntrans))
     allocate (isdf_in%myncv_sym(gvec%syms%ntrans))
     allocate (isdf_in%mync_sym(gvec%syms%ntrans))
     allocate (isdf_in%mynv_sym(gvec%syms%ntrans))
-    isdf_in%ncv_sym = 0
     isdf_in%myncv_sym = 0
     isdf_in%mync_sym = 0
     isdf_in%mynv_sym = 0
@@ -404,9 +409,6 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         isdf_in%myncv_sym(irep) = isdf_in%myncv_sym(irep) + &
                                   (isdf_in%lvrep_bound(lrp1, 2) - isdf_in%lvrep_bound(lrp1, 1) + 1)* &
                                   (isdf_in%lcrep_bound(lrp2, 2) - isdf_in%lcrep_bound(lrp2, 1) + 1)
-        isdf_in%ncv_sym(irep) = isdf_in%ncv_sym(irep) + &
-                                (isdf_in%lrep_bound(lrp1, 3) - isdf_in%lrep_bound(lrp1, 1) + 1)* &
-                                (isdf_in%lrep_bound(lrp2, 2) - isdf_in%lrep_bound(lrp2, 3))
         ! lrep_bound(:,2) largest empty state index
         ! lrep_bound(:,3) largest occupied state index
 
@@ -432,14 +434,6 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
     !  endif
     !  call MPI_BARRIER(peinf%comm, info)
     !enddo ! ipe
-    !if (peinf%master) then
-    !do irep = 1, gvec%syms%ntrans
-    !  if(tmp_count(irep) .ne. isdf_in%ncv_sym(irep)) then
-    !    print *, irep, " tmp_count ", tmp_count(irep), &
-    !      " ncv_sym ", isdf_in%ncv_sym(irep)
-    !  endif
-    !enddo
-    !endif
     isdf_in%maxmyncv_sym = maxval(isdf_in%myncv_sym)
     isdf_in%maxmync_sym = maxval(isdf_in%mync_sym)
     isdf_in%maxmynv_sym = maxval(isdf_in%mynv_sym)
@@ -515,6 +509,12 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         end do ! kk
       end if
     end do ! irep
+
+
+    if (w_grp%master) then
+      write (*, "(/, A)") repeat('-', 65)
+      call stopwatch(peinf%master, "Starting Sigma loop")
+    end if
     allocate (sigma_corr_tmp(sig_in%nen + 1, jnblock))
     allocate (sigma_corr(sig_in%nen))
     deltae = sig_in%deltae/(sig_in%nen - 1) ! in rydberg
@@ -551,7 +551,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
 
             do iblk = 1, nblks(irep)
               if (peinf%master) then
-                write (6, "(/, A)") repeat('-', 65)
+                write (6, "(A)") repeat('-', 65)
                 write (6, "(10(A, I0))") " ik: ", ik, "/", nkpt, "   isp: ", isp, "/", nspin, "   isig: ", isig, &
                   "/", sig_in%ndiag, "   irep: ", irep, "/", gvec%syms%ntrans, "   iblk: ", iblk, "/",  nblks(irep)
               end if
@@ -758,14 +758,15 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
           end do ! irep
 
           if (peinf%master) then
-            write (*, "(/, A)") repeat('-', 65)
+            write (*, "(A)") repeat('-', 65)
             write (*, "(A, I0)") " iband = ", sig_in%map(sig_in%diag(isig))
             write (*, "(A)") "     iE       E      sigma_c(re) sigma_c(im)   E_qp(E)  # in (eV)"
             do ien = 1, sig_in%nen
-              write (6, "(I7, 4F12.6)") ien, ryd*(deltae*(ien-1)+en0), &
+              write (*, "(I7, 4F12.6)") ien, ryd*(deltae*(ien-1)+en0), &
                 real(sigma_corr(ien))*ryd, aimag(sigma_corr(ien))*ryd, &
                 (kpt%wfn(1, 1)%e1(m1)+real(sig(1, 1)%xdiag(isig)+sigma_corr(ien)-sig(1, 1)%vxcdiag(isig)))*ryd
             end do ! ien
+            write (*, *)
           end if ! peinf%master
           do ien = 1, sig_in%nen
             sig(isp, ik)%scdiag(ien, isig) = real(sigma_corr(ien))

--- a/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
+++ b/SIGMA/calculate_sigma_lanczos_lowcomsym.F90z
@@ -254,7 +254,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         emin = (kpt%wfn(1, 1)%e1(nval + 1) - kpt%wfn(1, 1)%e1(nval))**2.0/1.25d0
         emax = (kpt%wfn(1, 1)%e1(isdf_in%maxicc) - kpt%wfn(1, 1)%e1(1))**2.0*1.25d0
         print *, "emin = ", emin, " emax = ", emax
-        !call polyfit_sqrt(emin, emax, npoly, 20, peinf%inode, tmp_poly, .False.)
+        ! call polyfit_sqrt(emin, emax, npoly, 20, peinf%inode, tmp_poly, .False.)
         ! search for best polynomial fitting
         max_fit_error = 1.d3
         do nx = 20, 300, 20
@@ -525,10 +525,10 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         blks(nblks(irep), 3, irep) = 0
       end if
       if (w_grp%master) then
-        print *, " ncblks nvblks ", ncblks(irep), nvblks(irep)
-        print *, " idx   blks "
+        write (*, "(3(A, I0))") " irep = ", irep, "  nvblks = ", nvblks(irep), "  ncblks = ", ncblks(irep)
+        write (*, *) "  idx   blks "
         do kk = 1, nblks(irep)
-          print *, kk, blks(kk, 1:3, irep)
+          write (*, *) kk, blks(kk, 1:3, irep)
         end do ! kk
       end if
     end do ! irep
@@ -567,8 +567,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
             end do ! jvrep loop
             do iblk = 1, nblks(irep)
               if (peinf%master) then
-                write (6, '(/,a)') repeat('-', 65)
-                write (6, '(10(a,i0))') " ik: ", ik, "/", nkpt, "   isp: ", isp, "/", nspin, "   isig: ", isig, &
+                write (6, "(/, A)") repeat('-', 65)
+                write (6, "(10(A, I0))") " ik: ", ik, "/", nkpt, "   isp: ", isp, "/", nspin, "   isig: ", isig, &
                   "/", sig_in%ndiag, "   irep: ", irep, "/", gvec%syms%ntrans, "   iblk: ", iblk, "/",  nblks(irep)
               end if
               ! ----------------------------------------------------------------
@@ -591,7 +591,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
               jn = blks(iblk, 1, irep) + isdf_in%lrep_bound(irep, 1) - 1
               jnend = blks(iblk, 2, irep) + isdf_in%lrep_bound(irep, 1) - 1
               blksz = jnend - jn + 1
-              call stopwatch(peinf%master, " prepare Pvec ")
+              call stopwatch(peinf%master, " Initializing Pvec")
               tmp_Cvec = 0.d0
               do kk = 1, blksz
                 jk = isdf_in%lrep(jn + kk - 1)
@@ -644,8 +644,7 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
                   end do ! jcrep
 #ifdef DCU
                   Nbytes = isdf_in%n_intp_r*blksz*Bytes_double
-                  call hipCheck(hipMemcpy(d_cvec, c_loc(tmp_Cvec), Nbytes,
-                  hipMemcpyHostToDevice))
+                  call hipCheck(hipMemcpy(d_cvec, c_loc(tmp_Cvec), Nbytes, hipMemcpyHostToDevice))
                   call hadamard_prod_mat_sym(d_PsiV, d_PsiC, d_Cmtrx, d_lcrep, isdf_in%n_intp_r, jv - 1, isdf_in%mynv, &
                                              isdf_in%mync, isdf_in%maxmync_sym, isdf_in%lcrep_bound(jcrep, 1), &
                                              isdf_in%lcrep_bound(jcrep, 2))
@@ -725,137 +724,67 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
               do kk = 1, blksz
                 pnorm(kk) = sqrt(pnorm2(kk))
               end do ! kk
-              call stopwatch(peinf%master, " Finished preparing Pvec ")
-              !if (w_grp%master) print *, "pnorm**2 ", pnorm2(1:blksz)
-              !stop
 
+              call stopwatch(peinf%master, " Running Lanczos solver")
               if (blks(iblk, 3, irep) == 1) then ! occupied states
-
-                do kk = 1, blksz
-                  jk = isdf_in%lrep(jn + kk - 1)
-                  ezz(1:sig_in%nen, kk) = -zz(1:sig_in%nen) + kpt%wfn(isp, ik)%e1(jk) + cmplx(0.d0, 1.d0)*ecuts
-                end do ! kk
-                ezz(sig_in%nen + 1, 1:blksz) = cmplx(0.d0, 0.d0)
-                ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
-                call lanczos_spectra_isdf_lowcomsym(Pvec, pnorm, isdf_in%myncv_sym(nmrep), ezz, sig_in%nen + 1, &
-                                                    opt%lanczos_niter, isdf_in, sqrtR, polynomial, npoly, &
-                                                    sigma_corr_tmp, tamm_d, blksz, nmrep, gvec &
-#ifdef DCU
-                                                    , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, d_cvec, d_lcrep, &
-                                                    handle &
-#elif defined _CUDA
-                                                    , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, d_cvec, d_lcrep, &
-                                                    vstep, tmp_Cvec, streamid &
-#endif
-                                                    )
-                do kk = 1, blksz
-                  if (tamm_d) then
-                    ! TODO: Check if sqrt(2) factor is correct in sigma_corr adjustment
-                    sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) - &
-                                               sigma_corr_tmp(1:sig_in%nen, kk)*2.0**0.5*pnorm2(kk)
-                  else
-                    sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + &
-                                               (sigma_corr_tmp(sig_in%nen + 1, kk) &
-                                                - sigma_corr_tmp(1:sig_in%nen, kk)) &
-                                               *2.0*pnorm2(kk)/ezz(1:sig_in%nen, kk)
-                  end if
-
-#ifdef DEBUG
-                  if (peinf%master) then
-                    if (tamm_d) then
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", -sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
-                      do ien = 1, sig_in%nen
-                        write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
-                          m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
-                          real(-sigma_corr_tmp(ien, kk))*2.0**0.5*pnorm2(kk)*ryd
-                      end do ! ien
-                    else
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))*2.0*pnorm2(kk)/ezz(2, kk)
-                      do ien = 1, sig_in%nen
-                        write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
-                          m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
-                          real((sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(ien, kk))* &
-                            2.0*pnorm2(kk)/ezz(ien, kk))*ryd
-                      end do ! ien
-                    end if
-                  end if
-#endif
-                end do ! kk
-
-              else ! for unoccupied states
-
-                do kk = 1, blksz
-                  jk = isdf_in%lrep(jn + kk - 1)
-                  ezz(1:sig_in%nen, kk) = zz(1:sig_in%nen) - kpt%wfn(isp, ik)%e1(jk) + cmplx(0.d0, 1.d0)*ecuts
-                end do ! kk
-                ezz(sig_in%nen + 1, 1:blksz) = cmplx(0.d0, 0.d0)
-                ! call lanczos_spectra to compute <Pvec| 1/(ezz-H_aux) |Pvec>
-                call lanczos_spectra_isdf_lowcomsym(Pvec, pnorm, isdf_in%myncv_sym(nmrep), ezz, sig_in%nen + 1, &
-                                                    opt%lanczos_niter, isdf_in, sqrtR, polynomial, npoly, &
-                                                    sigma_corr_tmp, tamm_d, blksz, nmrep, gvec &
-#ifdef DCU
-                                                    , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, &
-                                                    d_cvec, d_lcrep, handle &
-#elif defined _CUDA
-                                                    , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, &
-                                                    d_cvec, d_lcrep, vstep, tmp_Cvec, streamid &
-#endif
-                                                    )
-                do kk = 1, blksz
-                  if (tamm_d) then
-                    ! TODO: Check if sqrt(2) factor is correct in sigma_corr adjustment
-                    sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + &
-                                               sigma_corr_tmp(1:sig_in%nen, kk)*2.0**0.5*pnorm2(kk)
-                  else
-                    sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) - &
-                                               (sigma_corr_tmp(sig_in%nen + 1, kk) &
-                                                - sigma_corr_tmp(1:sig_in%nen, kk)) &
-                                                *2.0*pnorm2(kk)/ezz(1:sig_in%nen, kk)
-                  end if
-#ifdef DEBUG
-                  if (peinf%master) then
-                    if (tamm_d) then
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", sigma_corr_tmp(2, kk)*2.0**0.5*pnorm2(kk)
-                      do ien = 1, sig_in%nen
-                        write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
-                          m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
-                          real(sigma_corr_tmp(ien, kk))*2.0**0.5*pnorm2(kk)*ryd
-                      end do ! ien
-                    else
-                      print *, isdf_in%lrep(jn + kk - 1), "incr ", &
-                        (sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(2, kk))*2.0*pnorm2(kk)/ezz(2, kk)
-                      do ien = 1, sig_in%nen
-                        write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
-                          m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), &
-                          real((sigma_corr_tmp(sig_in%nen + 1, kk) - sigma_corr_tmp(ien, kk))* &
-                            2.0*pnorm2(kk)/ezz(ien, kk))*ryd
-                      end do ! ien
-                    end if
-                  end if
-#endif
-                end do ! kk
+                occ = 1.d0
+              else ! unoccupied states
+                occ = -1.d0
               end if
 
-              call stopwatch(peinf%master, ' summation over bands ')
+              do kk = 1, blksz
+                jk = isdf_in%lrep(jn + kk - 1)
+                ezz(1:sig_in%nen, kk) = (-zz(1:sig_in%nen) + kpt%wfn(isp, ik)%e1(jk)) * occ + cmplx(0.d0, 1.d0)*ecuts
+              end do ! kk
+              ezz(sig_in%nen + 1, 1:blksz) = cmplx(0.d0, 0.d0)
 
+              ! compute <Pvec| 1/(ezz-H_aux) |Pvec>
+              call lanczos_spectra_isdf_lowcomsym(Pvec, pnorm, isdf_in%myncv_sym(nmrep), ezz, sig_in%nen + 1, &
+                                                  opt%lanczos_niter, isdf_in, sqrtR, polynomial, npoly, &
+                                                  sigma_corr_tmp, tamm_d, blksz, nmrep, gvec &
+#ifdef DCU
+                                                  , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, d_cvec, d_lcrep, &
+                                                  handle &
+#elif defined _CUDA
+                                                  , d_PsiV, d_PsiC, d_Cmtrx, d_pvec, d_cvec, d_lcrep, &
+                                                  vstep, tmp_Cvec, streamid &
+#endif
+                                                  )
+
+              call stopwatch(peinf%master, " Summing over bands")
+              do kk = 1, blksz
+                if (tamm_d) then
+                  ! TODO: Check if factor 2 is correct in sigma_corr adjustment
+                  sigma_corr_tmp(1:sig_in%nen, kk) = -sigma_corr_tmp(1:sig_in%nen, kk)*occ*2.0*pnorm2(kk)
+                else
+                  sigma_corr_tmp(1:sig_in%nen, kk) = (sigma_corr_tmp(sig_in%nen + 1, kk) &
+                                                      -sigma_corr_tmp(1:sig_in%nen, kk)) &
+                                                     *occ*2.0*pnorm2(kk)/ezz(1:sig_in%nen, kk)
+                end if
+                ! TODO: Check if factor 2 is correct in sigma_corr adjustment
+                sigma_corr(1:sig_in%nen) = sigma_corr(1:sig_in%nen) + sigma_corr_tmp(1:sig_in%nen, kk)
+#ifdef DEBUG
+                if (peinf%master) then
+                  print *, isdf_in%lrep(jn + kk - 1), "incr ", sigma_corr_tmp(2, kk)
+                  do ien = 1, sig_in%nen
+                    write (dbgunit, '(i7,3x,i7,3x,i7,3x,e15.5,3x,e15.5)') &
+                      m1, isdf_in%lrep(jn + kk - 1), ien, real(zz(ien)), real(sigma_corr_tmp(ien, kk))*ryd
+                  end do ! ien
+                end if
+#endif
+              end do ! kk
             end do ! iblk
-
             deallocate (Pvec)
-
           end do ! irep
 
           if (peinf%master) then
-            write (6, '(a)') repeat('-', 65)
-            print *, "sigma_corr", sig_in%map(sig_in%diag(isig))
+            write (*, "(/, A)") repeat('-', 65)
+            write (*, "(A, I0)") " iband = ", sig_in%map(sig_in%diag(isig))
+            write (*, "(A)") "     iE       E      sigma_c(re) sigma_c(im)   E_qp(E)  # in (eV)"
             do ien = 1, sig_in%nen
-              write (6, '(a,i7,f15.6,f15.6,f15.6)') " #sigma_c ", ien, ryd*(deltae*(ien - 1) + en0), &
-                  real(sigma_corr(ien))*ryd, aimag(sigma_corr(ien))*ryd
-            end do ! ien
-            print *, "E_qp(E)", sig_in%map(sig_in%diag(isig))
-            do ien = 1, sig_in%nen
-              write (6, '(a,i7,f15.6,f15.6)') " #E_qp ", ien, ryd*(deltae*(ien - 1) + en0), &
-                (kpt%wfn(1, 1)%e1(m1) + real(sig(1, 1)%xdiag(isig) + sigma_corr(ien) - sig(1, 1)%vxcdiag(isig)))*ryd
+              write (6, "(I7, 4F12.6)") ien, ryd*(deltae*(ien-1)+en0), &
+                real(sigma_corr(ien))*ryd, aimag(sigma_corr(ien))*ryd, &
+                (kpt%wfn(1, 1)%e1(m1)+real(sig(1, 1)%xdiag(isig)+sigma_corr(ien)-sig(1, 1)%vxcdiag(isig)))*ryd
             end do ! ien
           end if ! peinf%master
           do ien = 1, sig_in%nen
@@ -867,6 +796,8 @@ subroutine Zcalculate_sigma_lanczos_lowcomsym(nspin, nkpt, sig_en, dft_code, gve
         end do ! isig
       end do ! isp
     end do ! ik
+    deallocate (sigma_corr_tmp)
+    deallocate (sigma_corr)
     deallocate (zz, ezz)
     deallocate (tmp_Cmtrx)
     deallocate (tmp_Cvec)

--- a/SIGMA/sigma.F90
+++ b/SIGMA/sigma.F90
@@ -740,8 +740,7 @@ program sigma
              isdf_in%lessmemory == 3 .or. &
              isdf_in%lessmemory == 4) then
       if (peinf%master) print *, " call isdf_parallel_sym_UltraLowMem"
-      call isdf_parallel_sym_UltraLowMem(gvec, pol_in, kpt, nspin, isdf_in, &
-                                         kflag, opt, verbose)
+      call isdf_parallel_sym_UltraLowMem(gvec, kpt, nspin, isdf_in, kflag, opt, verbose)
       if (peinf%master) print *, " done isdf"
       do kk = 91, 92
         jj = 3
@@ -1133,43 +1132,49 @@ program sigma
   ! Time accounting.
   !
   ii = 13
-  ik = 33-13
+  ik = 39-13
   allocate (routnam(ii + ik))
   allocate (timerlist(ii + ik))
-  routnam(1) = 'SETUP_S'; timerlist(1) = 2
-  routnam(2) = 'KERNEL'; timerlist(2) = 3
-  routnam(3) = 'DIAG_POL'; timerlist(3) = 4
-  routnam(4) = 'WPOL_0'; timerlist(4) = 5
-  routnam(5) = 'EXCHANGE'; timerlist(5) = 6
-  routnam(6) = 'POTENTIAL'; timerlist(6) = 7
-  routnam(7) = 'CORRELATION'; timerlist(7) = 8
-  routnam(8) = 'VERTEX'; timerlist(8) = 9
-  routnam(9) = 'ROTATE'; timerlist(9) = 10
-  routnam(10) = 'CVT'; timerlist(10) = 51
-  routnam(11) = 'ISDF'; timerlist(11) = 52
-  routnam(12) = 'VXC'; timerlist(12) = 55
-  routnam(13) = 'LANCZOS'; timerlist(13) = 56
+  routnam(1) = "SETUP_S"; timerlist(1) = 2
+  routnam(2) = "KERNEL"; timerlist(2) = 3
+  routnam(3) = "DIAG_POL"; timerlist(3) = 4
+  routnam(4) = "WPOL_0"; timerlist(4) = 5
+  routnam(5) = "EXCHANGE"; timerlist(5) = 6
+  routnam(6) = "POTENTIAL"; timerlist(6) = 7
+  routnam(7) = "CORRELATION"; timerlist(7) = 8
+  routnam(8) = "VERTEX"; timerlist(8) = 9
+  routnam(9) = "ROTATE"; timerlist(9) = 10
+  routnam(10) = "CVT"; timerlist(10) = 51
+  routnam(11) = "ISDF"; timerlist(11) = 52
+  routnam(12) = "VXC"; timerlist(12) = 55
+  routnam(13) = "LANCZOS"; timerlist(13) = 56
 
-  routnam(14) = 'POISSON_FFT'; timerlist(14) = 11
-  routnam(15) = 'EIGENSOLVER'; timerlist(15) = 12
-  routnam(16) = 'INTEGRATION'; timerlist(16) = 13
-  routnam(17) = 'Calc intp vectors'; timerlist(17) = 53
-  routnam(18) = 'Calc <zeta|K|zeta>'; timerlist(18) = 54
-  routnam(19) = '(in cvt step1)'; timerlist(19) = 61
-  routnam(20) = '(in cvt step2)'; timerlist(20) = 62
-  routnam(21) = 'k_integrate_isdf'; timerlist(21) = 63
-  routnam(22) = 'kernel k_print'; timerlist(22) = 64
-  routnam(23) = 'k_int_isdf 1'; timerlist(23) = 65
-  routnam(24) = 'k_int_isdf 2'; timerlist(24) = 66
-  routnam(25) = 'k_int_isdf 3'; timerlist(25) = 67
-  routnam(26) = 'Lanczos_matvec'; timerlist(26) = 58
-  routnam(27) = 'Lanczos_poly'; timerlist(27) = 57
-  routnam(28) = 'matvec: sqR@vec'; timerlist(28) = 68
-  routnam(29) = 'matvec: Hadamard'; timerlist(29) = 69
-  routnam(30) = 'matvec: C@vec'; timerlist(30) = 71
-  routnam(31) = 'matvec: M@vec'; timerlist(31) = 72
-  routnam(32) = 'matvec: mpi'; timerlist(32) = 70
-  routnam(33) = 'matvec: vec_final'; timerlist(33) = 73
+  routnam(14) = "POISSON_FFT"; timerlist(14) = 11
+  routnam(15) = "EIGENSOLVER"; timerlist(15) = 12
+  routnam(16) = "INTEGRATION"; timerlist(16) = 13
+  routnam(17) = "Calc intp vectors"; timerlist(17) = 53
+  routnam(18) = "Calc <zeta|K|zeta>"; timerlist(18) = 54
+  routnam(19) = "(in cvt step1)"; timerlist(19) = 61
+  routnam(20) = "(in cvt step2)"; timerlist(20) = 62
+  routnam(21) = "k_integrate_isdf"; timerlist(21) = 63
+  routnam(22) = "kernel k_print"; timerlist(22) = 64
+  routnam(23) = "k_int_isdf 1"; timerlist(23) = 65
+  routnam(24) = "k_int_isdf 2"; timerlist(24) = 66
+  routnam(25) = "k_int_isdf 3"; timerlist(25) = 67
+  routnam(26) = "ISDF_P & Q"; timerlist(26) = 53
+  routnam(27) = "ISDF_dgemm1"; timerlist(27) = 78
+  routnam(28) = "ISDF_Hadamard"; timerlist(28) = 80
+  routnam(29) = "ISDF_Mmtrx"; timerlist(29) = 54
+  routnam(30) = "ISDF_dgemm2"; timerlist(30) = 77
+  routnam(31) = "ISDF_dpoisson"; timerlist(31) = 79
+  routnam(32) = "Lanczos_matvec"; timerlist(32) = 58
+  routnam(33) = "Lanczos_poly"; timerlist(33) = 57
+  routnam(34) = "matvec_sqR@vec"; timerlist(34) = 68
+  routnam(35) = "matvec_Hadamard"; timerlist(35) = 69
+  routnam(36) = "matvec_C@vec"; timerlist(36) = 71
+  routnam(37) = "matvec_M@vec"; timerlist(37) = 72
+  routnam(38) = "matvec_mpi"; timerlist(38) = 70
+  routnam(39) = "matvec_vec_final"; timerlist(39) = 73
 
 #ifdef HIPMAGMA
   !if (opt%linear_algebra .eq. 2 .or. opt%eigsolver .eq. 2) then

--- a/config/make.stampede3.h
+++ b/config/make.stampede3.h
@@ -7,7 +7,7 @@
 #  2) impi/21.11   4) cmake/3.28.1    6) TACC
 #
 FCPP    = /usr/bin/cpp -P -traditional-cpp
-CPPOPT  = -DUSEFFTW3 -DMPI -DINTEL # -DDEBUG
+CPPOPT  = -DUSEFFTW3 -DMPI -DINTEL  # -DDEBUG
 
 EXT     = .mpi
 

--- a/shared/lanczos_spectra_lowcomsym.F90
+++ b/shared/lanczos_spectra_lowcomsym.F90
@@ -4,7 +4,6 @@
 !
 !  <vec| 1/(z-H) |vec>
 !
-! ncv_loc = isdf_in%ncv_sym(nmrep)
 subroutine lanczos_spectra_isdf_lowcomsym(v0, v0_norm, ncv_loc, zz, nz, niter, isdf_in, sqrtR, polynomial, npoly, &
                                           spectra, tamm_d, blksz, nmrep, gvec &
 #ifdef DCU

--- a/shared/redistribute_psi_loc.F90z
+++ b/shared/redistribute_psi_loc.F90z
@@ -1,24 +1,22 @@
 #include "../shared/mycomplex.h"
 
 subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
-  !
+
   use typedefs
   use mpi_module
   implicit none
 #ifdef MPI
   include 'mpif.h'
 #endif
-  !
+
   integer, intent(in) :: nval, ncond
   type(ISDF), intent(inout) :: isdf_in
-  integer :: ldn_intp_r, mpistatus(MPI_STATUS_SIZE), &
-             xvgrp, xcgrp, myvgrp, mycgrp, mynv, mync, ii, &
-             ldv, ldc, myvstart, myvend, mycstart, mycend, &
-             xvgrp_c, igrp, icgrp, &
-             ivgrp, ipe, send_node, recv_node, tag, mpi_err, &
+  integer :: ldn_intp_r, mpistatus(MPI_STATUS_SIZE), xvgrp, xcgrp, myvgrp, mycgrp, mynv, mync, ii, ldv, ldc, &
+             myvstart, myvend, mycstart, mycend, xvgrp_c, igrp, icgrp, ivgrp, ipe, send_node, recv_node, tag, mpi_err, &
              incr, res, i1, i2, j1, j2
   SCALAR, allocatable :: tmparray(:)
-  !
+  integer, allocatable :: vstart(:), cstart(:), vend(:), cend(:)
+
   ldn_intp_r = w_grp%ldn_intp_r
   xvgrp = int(sqrt(real(w_grp%npes*nval/ncond) + 1e-6))
   if (xvgrp <= 1) then
@@ -42,8 +40,7 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
       call die(" xcgrp * xvgrp \= w_grp%npes ")
     end if
   end if
-  if (peinf%master) print *, " xcgrp = ", xcgrp, " xvgrp = ", xvgrp, &
-    " w_grp%npes ", w_grp%npes
+  if (peinf%master) print *, " xcgrp = ", xcgrp, " xvgrp = ", xvgrp, " w_grp%npes ", w_grp%npes
   ! An example of distributing 24 process to 4 vgrp and 6 cgrp
   !___|__0___1___2___3____ xvgrp = 4
   ! 0 |  0   1   2   3   |
@@ -62,10 +59,10 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
   !    print *, " w_grp%inode ", w_grp%inode, myvgrp, mycgrp
   !  endif
   !enddo
-  allocate (isdf_in%vstart(0:(xvgrp - 1)))
-  allocate (isdf_in%vend(0:(xvgrp - 1)))
-  allocate (isdf_in%cstart(0:(xcgrp - 1)))
-  allocate (isdf_in%cend(0:(xcgrp - 1)))
+  allocate (vstart(0:(xvgrp - 1)))
+  allocate (vend(0:(xvgrp - 1)))
+  allocate (cstart(0:(xcgrp - 1)))
+  allocate (cend(0:(xcgrp - 1)))
   !
   ! distribute nval to xvgrp
   incr = nval/xvgrp
@@ -77,16 +74,16 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
   end if
   do igrp = 0, xvgrp - 1
     if (igrp < res) then
-      isdf_in%vstart(igrp) = igrp*(incr + 1) + 1
-      isdf_in%vend(igrp) = igrp*(incr + 1) + incr + 1
+      vstart(igrp) = igrp*(incr + 1) + 1
+      vend(igrp) = igrp*(incr + 1) + incr + 1
     else
-      isdf_in%vstart(igrp) = res*(incr + 1) + (igrp - res)*incr + 1
-      isdf_in%vend(igrp) = res*(incr + 1) + (igrp - res)*incr + incr
+      vstart(igrp) = res*(incr + 1) + (igrp - res)*incr + 1
+      vend(igrp) = res*(incr + 1) + (igrp - res)*incr + incr
     end if
   end do
-  myvstart = isdf_in%vstart(myvgrp)
-  myvend = isdf_in%vend(myvgrp)
-  mynv = isdf_in%vend(myvgrp) - isdf_in%vstart(myvgrp) + 1
+  myvstart = vstart(myvgrp)
+  myvend = vend(myvgrp)
+  mynv = vend(myvgrp) - vstart(myvgrp) + 1
   ! distribute ncond to xcgrp
   incr = ncond/xcgrp
   res = mod(ncond, xcgrp)
@@ -97,16 +94,16 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
   end if
   do igrp = 0, xcgrp - 1
     if (igrp < res) then
-      isdf_in%cstart(igrp) = igrp*(incr + 1) + 1
-      isdf_in%cend(igrp) = igrp*(incr + 1) + incr + 1
+      cstart(igrp) = igrp*(incr + 1) + 1
+      cend(igrp) = igrp*(incr + 1) + incr + 1
     else
-      isdf_in%cstart(igrp) = res*(incr + 1) + (igrp - res)*incr + 1
-      isdf_in%cend(igrp) = res*(incr + 1) + (igrp - res)*incr + incr
+      cstart(igrp) = res*(incr + 1) + (igrp - res)*incr + 1
+      cend(igrp) = res*(incr + 1) + (igrp - res)*incr + incr
     end if
   end do
-  mycstart = isdf_in%cstart(mycgrp)
-  mycend = isdf_in%cend(mycgrp)
-  mync = isdf_in%cend(mycgrp) - isdf_in%cstart(mycgrp) + 1
+  mycstart = cstart(mycgrp)
+  mycend = cend(mycgrp)
+  mync = cend(mycgrp) - cstart(mycgrp) + 1
   !do ii = 0, 30
   !  if (ii .gt. w_grp%npes-1) exit
   !  if (w_grp%inode .eq. ii) then
@@ -127,8 +124,8 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
     j2 = w_grp%n_intp_end(ipe)
     !if (w_grp%master) print *, " ipe ", ipe, " j1 ", j1, " j2 ", j2
     do ivgrp = 0, xvgrp - 1
-      i1 = isdf_in%vstart(ivgrp)
-      i2 = isdf_in%vend(ivgrp)
+      i1 = vstart(ivgrp)
+      i2 = vend(ivgrp)
       !if (w_grp%master) print *, " i1 ", i1, " i2 ", i2
       do icgrp = 0, xcgrp - 1
         recv_node = icgrp*xvgrp + ivgrp
@@ -165,21 +162,21 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
     end do ! ivgrp
   end do ! ipe
   deallocate (tmparray)
-!  if (w_grp%master) print *, " finish redistribut PsiV_intp_bl "
-!  do ipe = 0, w_grp%npes-1
-!  if (w_grp%inode .eq. ipe) then
-!    print *, "PsiV_intp_bl ", ipe
-!    call printmatrix(isdf_in%PsiV_intp_bl(1,1,1,1), isdf_in%n_intp_r, mynv, 6)
-!  endif
-!  call mpi_barrier(w_grp%comm, mpi_err)
-!  enddo
-!  do ipe = 0, w_grp%npes-1
-!  if (w_grp%inode .eq. ipe) then
-!    print *, "Psi_intp_loc", ipe
-!    call printmatrix(isdf_in%Psi_intp_loc(1,1,1,1), w_grp%myn_intp_r, nval, 6)
-!  endif
-!  call mpi_barrier(w_grp%comm, mpi_err)
-!  enddo
+  ! if (w_grp%master) print *, " finish redistribut PsiV_intp_bl "
+  ! do ipe = 0, w_grp%npes-1
+  ! if (w_grp%inode .eq. ipe) then
+  !   print *, "PsiV_intp_bl ", ipe
+  !   call printmatrix(isdf_in%PsiV_intp_bl(1,1,1,1), isdf_in%n_intp_r, mynv, 6)
+  ! endif
+  ! call mpi_barrier(w_grp%comm, mpi_err)
+  ! enddo
+  ! do ipe = 0, w_grp%npes-1
+  ! if (w_grp%inode .eq. ipe) then
+  !   print *, "Psi_intp_loc", ipe
+  !   call printmatrix(isdf_in%Psi_intp_loc(1,1,1,1), w_grp%myn_intp_r, nval, 6)
+  ! endif
+  ! call mpi_barrier(w_grp%comm, mpi_err)
+  ! enddo
 
   allocate (tmparray(ldn_intp_r*ldc))
   do ipe = 0, w_grp%npes - 1
@@ -188,8 +185,8 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
     j2 = w_grp%n_intp_end(ipe)
     !if (w_grp%master) print *, " ipe ", ipe, " j1 ", j1, " j2 ", j2
     do icgrp = 0, xcgrp - 1
-      i1 = isdf_in%cstart(icgrp)
-      i2 = isdf_in%cend(icgrp)
+      i1 = cstart(icgrp)
+      i2 = cend(icgrp)
       !if (w_grp%master) print *, " i1 ", i1, " i2 ", i2
       do ivgrp = 0, xvgrp - 1
         recv_node = icgrp*xvgrp + ivgrp
@@ -198,15 +195,12 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
         if (send_node /= recv_node) then
           !print *, " inode ", w_grp%inode, " comm "
           if (w_grp%inode == send_node) then
-            call mpi_send(isdf_in%Psi_intp_loc(1, nval + i1, 1, 1), &
-                          (j2 - j1 + 1)*(i2 - i1 + 1), &
-                          MPI_DOUBLE_SCALAR, recv_node, tag, &
-                          w_grp%comm, mpi_err)
+            call mpi_send(isdf_in%Psi_intp_loc(1, nval + i1, 1, 1), (j2 - j1 + 1)*(i2 - i1 + 1), MPI_DOUBLE_SCALAR, &
+                          recv_node, tag, w_grp%comm, mpi_err)
           end if
           if (w_grp%inode == recv_node) then
-            call mpi_recv(tmparray, (j2 - j1 + 1)*(i2 - i1 + 1), &
-                          MPI_DOUBLE_SCALAR, send_node, tag, &
-                          w_grp%comm, mpistatus, mpi_err)
+            call mpi_recv(tmparray, (j2 - j1 + 1)*(i2 - i1 + 1), MPI_DOUBLE_SCALAR, send_node, tag, w_grp%comm, &
+                          mpistatus, mpi_err)
             isdf_in%PsiC_intp_bl(j1:j2, 1:(i2 - i1 + 1), 1, 1) = &
               reshape(tmparray(1:(j2 - j1 + 1)*(i2 - i1 + 1)), (/j2 - j1 + 1, i2 - i1 + 1/))
           end if
@@ -226,6 +220,10 @@ subroutine Zredistribute_Psi_loc(isdf_in, nval, ncond)
     end do ! ivgrp
   end do ! ipe
   deallocate (tmparray)
+  deallocate (vstart)
+  deallocate (cstart)
+  deallocate (vend)
+  deallocate (cend)
   !if (w_grp%master) print *, " finish redistribut PsiC_intp_bl "
   !do ipe = 0, w_grp%npes-1
   !if (w_grp%inode .eq. ipe) then

--- a/shared/stopwatch.f90
+++ b/shared/stopwatch.f90
@@ -26,8 +26,7 @@ subroutine stopwatch(verbose, label)
 
   if (verbose) then
     call cpu_time(this_time)
-    write (6, '(a,f11.2,a,a)') ' ELAPSED TIME = ', &
-      this_time - start_time, ' s. ', label(1:len_trim(label))
+    write (6, "(A, F11.2, A, A)") " ELAPSED TIME = ", this_time - start_time, " s. ", label(1:len_trim(label))
     call flush (6)
   end if
 

--- a/shared/stopwatch.f90
+++ b/shared/stopwatch.f90
@@ -26,7 +26,7 @@ subroutine stopwatch(verbose, label)
 
   if (verbose) then
     call cpu_time(this_time)
-    write (6, "(A, F11.2, A, A)") " ELAPSED TIME = ", this_time - start_time, " s. ", label(1:len_trim(label))
+    write (6, "(A, F0.3, A, A)") " [ ", this_time - start_time, " s ] ", label(1:len_trim(label))
     call flush (6)
   end if
 

--- a/shared/timacc.f90
+++ b/shared/timacc.f90
@@ -50,8 +50,7 @@ subroutine timacc(n, option, tottim)
   ! Does n have valid value ?
   !
   if (n < 1 .or. n > MTIM) then
-    write (lastwords, '(a,i6,a,i8)') ' timacc: dim mtim=', MTIM, &
-      ' but input n= ', n
+    write (lastwords, '(a,i6,a,i8)') ' timacc: dim mtim=', MTIM, ' but input n= ', n
     call die(lastwords)
   end if
 
@@ -60,8 +59,7 @@ subroutine timacc(n, option, tottim)
   !
   call cpu_time(cpu)
   call date_and_time(VALUES=values)
-  wall = ((values(3)*24.0d0 + values(5))*60.0d0 + values(6))*60.0d0 &
-         + values(7) + values(8)*0.001d0
+  wall = ((values(3)*24.0d0 + values(5))*60.0d0 + values(6))*60.0d0 + values(7) + values(8)*0.001d0
 
   select case (option)
   case (1)

--- a/shared/typedefs.F90
+++ b/shared/typedefs.F90
@@ -68,7 +68,7 @@ module typedefs
     ! PsiC_intp_bl
     integer, pointer :: lvrep(:), lvrep_bound(:, :), &
                         lcrep(:), lcrep_bound(:, :)
-    integer, pointer :: ncv_sym(:), myncv_sym(:), mync_sym(:), mynv_sym(:)
+    integer, pointer :: myncv_sym(:), mync_sym(:), mynv_sym(:)
     integer :: maxmync_sym, maxmynv_sym, maxmyncv_sym
   end type ISDF
   !

--- a/shared/typedefs.F90
+++ b/shared/typedefs.F90
@@ -56,8 +56,7 @@ module typedefs
     real(dp), pointer :: PsiC_intp_bl(:, :, :, :), PsiV_intp_bl(:, :, :, :)
     integer :: xvgrp, xcgrp, myvgrp, mycgrp, mynv, mync, &
                ldv, ldc, myvstart, myvend, mycstart, mycend
-    integer, pointer :: vstart(:), cstart(:), &
-                        vend(:), cend(:)
+
     ! We assume nkp = nspin = 1 for now, kp and spin indices
     ! are needed later
     !


### PR DESCRIPTION
This PR includes optimizations in the Lanczos and ISDF sections.

Lanczos:
* Removed duplicate code and improved output.
* Combined occupied and empty state blocks.

ISDF:
* Made arrays like `vstart` local in `redistribute`.

General:
* Printed matrix sizes for debugging and improved output format.
* Improved timing information.